### PR TITLE
Add --unlock and --password to the start command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .idea/
 .vscode/
 
+# Node passwords
+password.txt
+
 # Logs
 logs
 npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -48,10 +48,25 @@ Examples:
 * Lists all running mosaic chain containers:
   * `./mosaic list`
 
+## Creating a new auxiliary chain
+
+Creating a new auxiliary chain assumes that you have an unlocked account on a node that is connected to the **origin chain.**
+If that is **not** the case, do one or more of the steps below as required.
+You should know what you are doing here.
+
+1. Make sure you have an origin node running. If that is not the case, start one (e.g. `./mosaic start ropsten`).
+2. Attach to the node (e.g. `./mosaic attach ropsten`).
+3. Create a new account (`personal.newAccount("password")`).
+4. Create a `./password.txt` (or different) file that contains `password` followed by a newline.
+5. Unlock the account (e.g. `./mosaic stop ropsten; ./mosaic start --unlock address --password ./password.txt ropsten`).
+6. You want to lock the account again after creating the auxiliary chain has finished (e.g. `./mosaic stop ropsten; ./mosaic start ropsten`).
+7. You may want to delete the password file.
+
 ## Tests
 
 Run the tests with `npm test`.
 
+<!-- TODO: delete below!
 ## Adding a new auxiliary chain
 
 1. Create a new directory `./utility_chains/utility_chain_<id>`.
@@ -59,3 +74,4 @@ Run the tests with `npm test`.
 3. Add `<id>` to the `CHAINS` array at the beginning of `build.sh`.
 4. Run `./build.sh` to generate all chain inits.
 5. Add `./utility_chains/utility_chain_<id>/environment.json` and add the relevant data (see other chains for examples).
+-->

--- a/src/Node/GethNode.ts
+++ b/src/Node/GethNode.ts
@@ -35,15 +35,24 @@ export default class GethNode extends Node {
     }
 
     args = args.concat([
-      '--network', `${Node.network}`,
+      '--network', Node.network,
       '--detach',
-      '--name', `${this.containerName}`,
+      '--name', this.containerName,
       '--publish', `${this.port}:30303`,
       '--publish', `${this.rpcPort}:8545`,
       '--publish', `${this.websocketPort}:8546`,
       '--volume', `${this.chainDir}:/chain_data`,
+    ]);
+
+    if (this.password !== '') {
+      args = args.concat([
+        '--volume', `${this.password}:/password.txt`
+      ]);
+    }
+
+    args = args.concat([
       'ethereum/client-go:v1.8.23',
-      '--networkid', `${this.chainId}`,
+      '--networkid', this.chainId,
       '--datadir', './chain_data',
       '--port', '30303',
       '--rpc',
@@ -56,8 +65,15 @@ export default class GethNode extends Node {
       '--wsport', '8546',
       '--wsapi', 'eth,net,web3,network,debug,txpool,admin,personal',
       '--wsorigins', '*',
-      '--bootnodes', `${this.bootnodes}`,
+      '--bootnodes', this.bootnodes,
     ]);
+
+    if (this.unlock !== '') {
+      args = args.concat([
+        '--unlock', this.unlock,
+        '--password', '/password.txt',
+      ]);
+    }
 
     Shell.executeDockerCommand(args);
   }

--- a/src/Node/Node.ts
+++ b/src/Node/Node.ts
@@ -25,6 +25,10 @@ export default abstract class Node {
   protected containerName: string;
   /** If set to true, the container is not deleted when stopped. */
   protected keepAfterStop: boolean;
+  /** A comma separated list of addresses that get unlocked while the process is running. */
+  protected unlock: string;
+  /** The path to the password file to unlock the accounts given in unlock. */
+  protected password: string;
 
   /**
    * Docker container names will have this prefix.
@@ -49,6 +53,8 @@ export default abstract class Node {
     this.rpcPort = nodeDescription.rpcPort;
     this.websocketPort = nodeDescription.websocketPort;
     this.keepAfterStop = nodeDescription.keepAfterStop;
+    this.unlock = nodeDescription.unlock;
+    this.password = Directory.sanitize(nodeDescription.password);
 
     this.chainDir = path.join(this.mosaicDir, this.chainId);
     this.containerName = `${Node.prefix}${this.chainId}`;

--- a/src/Node/NodeDescription.ts
+++ b/src/Node/NodeDescription.ts
@@ -8,6 +8,8 @@ export default class NodeDescription {
   rpcPort: number = 8545;
   websocketPort: number = 8645;
   keepAfterStop: boolean = false;
+  unlock: string = '';
+  password: string = '';
 
   constructor(chainId: string) {
     this.chainId = chainId;

--- a/src/Node/ParityNode.ts
+++ b/src/Node/ParityNode.ts
@@ -22,15 +22,24 @@ export default class ParityNode extends Node {
     }
 
     args = args.concat([
-      '--network', `${Node.network}`,
+      '--network', Node.network,
       '--detach',
-      '--name', `${this.containerName}`,
+      '--name', this.containerName,
       '--publish', `${this.port}:30303`,
       '--publish', `${this.rpcPort}:8545`,
       '--publish', `${this.websocketPort}:8546`,
       '--volume', `${this.chainDir}:/home/parity/.local/share/io.parity.ethereum/`,
+    ]);
+
+    if (this.password !== '') {
+      args = args.concat([
+        '--volume', `${this.password}:/home/parity/password.txt`
+      ]);
+    }
+
+    args = args.concat([
       'parity/parity:v2.3.4',
-      '--chain', `${this.chainId}`,
+      '--chain', this.chainId,
       '--base-path', '/home/parity/.local/share/io.parity.ethereum/',
       '--jsonrpc-apis', 'all',
       '--jsonrpc-interface', 'all',
@@ -41,6 +50,13 @@ export default class ParityNode extends Node {
       '--ws-origins', 'all',
       '--ws-hosts', 'all',
     ]);
+
+    if (this.unlock !== '') {
+      args = args.concat([
+        '--unlock', this.unlock,
+        '--password', '/home/parity/password.txt',
+      ]);
+    }
 
     Shell.executeDockerCommand(args);
   }


### PR DESCRIPTION
In order to have unlocked accounts with the nodes, we need to support unlocking accounts by providing addresses and the password file.

We need unlocked accounts in order to deploy contracts on origin when we create a new auxiliary chain.

References #19 