### PR TITLE
Set indent to 2 spaces

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,8 +15,9 @@
     "json"
   ],
   "rules": {
-    "no-underscore-dangle": "off",
+    "@typescript-eslint/indent": ["error", 2],
     "import/no-extraneous-dependencies": "off",
+    "no-underscore-dangle": "off",
     "strict": "off"
   },
   "env": {
@@ -28,5 +29,13 @@
     "artifacts": false,
     "contract": false,
     "assert": false
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [".js", ".jsx", ".ts", ".tsx"]
+      }
+    }
   }
 }
+

--- a/src/Config/InitConfig.ts
+++ b/src/Config/InitConfig.ts
@@ -9,19 +9,25 @@ import Directory from '../Directory';
 export default class InitConfig {
   /** The chain ID of the auxiliary chain that is to be created. */
   readonly auxiliaryChainId: string = '';
+
   /** Required to know the sender account when sending transactions to the origin node. */
-  readonly originTxOptions: { from: string, gasPrice: number };
+  readonly originTxOptions: { from: string; gasPrice: number };
+
   /** Bounty to set on the gateway on origin. */
   readonly originBounty: string = '';
+
   /** Bounty to set on the co-gateway on auxiliary. */
   readonly auxiliaryBounty: string = '';
 
   /** For the initial stake, the gas price to set. */
   readonly originStakeGasPrice: string = '';
+
   /** For the initial stake, the gas limit to set. */
   readonly originStakeGasLimit: string = '';
+
   /** The amount of OST to stake to initialize the auxiliary chain with, in Wei. */
   readonly originStakeAmount: string = '';
+
   /**
    * For the initial stake, wait this number of blocks after staking before reading the state root
    * from origin.
@@ -30,13 +36,16 @@ export default class InitConfig {
 
   /** The address of the OST EIP20 token on origin. */
   readonly originOstAddress: string = '';
+
   /** Where to send burned tokens on origin. */
   readonly originBurnerAddress: string = '';
+
   /** Where to send burned tokens on auxiliary. */
   readonly auxiliaryBurnerAddress: string = '';
 
   /** How many state roots to store in the anchor ring buffer on origin. */
   readonly originAnchorBufferSize: string = '';
+
   /** How many state roots to store in the anchor ring buffer on auxiliary. */
   readonly auxiliaryAnchorBufferSize: string = '';
 
@@ -49,10 +58,15 @@ export default class InitConfig {
    * the contracts, as it is required to activate the gateway and set the co-gateway on OST prime.
   */
   readonly originAnchorOrganizationOwner: string = '';
+
   readonly originAnchorOrganizationAdmin: string = '';
+
   readonly auxiliaryAnchorOrganizationOwner: string = '';
+
   readonly auxiliaryAnchorOrganizationAdmin: string = '';
+
   readonly originGatewayOrganizationOwner: string = '';
+
   readonly auxiliaryCoGatewayAndOstPrimeOrganizationOwner: string = '';
 
   /**
@@ -82,7 +96,7 @@ export default class InitConfig {
           `${auxiliaryChainId}.json`,
         ),
         { encoding: 'utf8' },
-      )
+      ),
     );
 
     fileValues.auxiliaryChainId = auxiliaryChainId;

--- a/src/Config/MosaicConfig.ts
+++ b/src/Config/MosaicConfig.ts
@@ -9,20 +9,30 @@ import Logger from '../Logger';
  */
 export default class MosaicConfig {
   public originChainId: string;
+
   public originAnchorOrganizationAddress: string;
+
   public originAnchorAddress: string;
+
   public originOstGatewayOrganizationAddress: string;
+
   public originOstGatewayAddress: string;
 
   // The original sealer and deployer on auxiliary when the chain was generated.
   public auxiliaryOriginalSealer: string;
+
   public auxiliaryOriginalDeployer: string;
 
   public auxiliaryChainId: string;
+
   public auxiliaryAnchorOrganizationAddress: string;
+
   public auxiliaryAnchorAddress: string;
+
   public auxiliaryCoGatewayAndOstPrimeOrganizationAddress: string;
+
   public auxiliaryOstPrimeAddress: string;
+
   public auxiliaryOstCoGatewayAddress: string;
 
   /**

--- a/src/Directory.ts
+++ b/src/Directory.ts
@@ -8,7 +8,7 @@ export default class Directory {
   /**
    * @returns The absolute path to the root of this project.
    */
-  static get projectRoot(): string {
+  public static get projectRoot(): string {
     return path.join(
       __dirname,
       '..',
@@ -18,7 +18,7 @@ export default class Directory {
   /**
    * @returns The absolute path to the utility chains directory in the project.
    */
-  static get projectUtilityChainsDir(): string {
+  public static get projectUtilityChainsDir(): string {
     return path.join(
       Directory.projectRoot,
       'utility_chains',
@@ -30,7 +30,7 @@ export default class Directory {
    * @returns The absolute path to the directory of the given utility chain.
    * @throws If `chainId` is an empty string.
    */
-  static getProjectUtilityChainDir(chainId: string): string {
+  public static getProjectUtilityChainDir(chainId: string): string {
     if (chainId === '') {
       throw new Error('a chain id cannot be empty in order to get its directory');
     }
@@ -47,19 +47,21 @@ export default class Directory {
    * - translates relative paths to absolute paths.
    * @param directory The directory string to sanitize.
    */
-  static sanitize(directory: string): string {
-    if (directory.substr(0, 1) === '~') {
-      directory = path.join(os.homedir(), directory.substr(1));
+  public static sanitize(directory: string): string {
+    let sanitized: string = directory;
+
+    if (sanitized.substr(0, 1) === '~') {
+      sanitized = path.join(os.homedir(), sanitized.substr(1));
     }
 
     // Relative directory name
-    if (directory.substr(0, 1) !== '/') {
-      directory = path.join(
+    if (sanitized.substr(0, 1) !== '/') {
+      sanitized = path.join(
         process.cwd(),
-        directory,
+        sanitized,
       );
     }
 
-    return directory;
+    return sanitized;
   }
 }

--- a/src/Integer.ts
+++ b/src/Integer.ts
@@ -1,4 +1,4 @@
-import Logger from './Logger'
+import Logger from './Logger';
 
 export default class Integer {
   /**
@@ -8,8 +8,8 @@ export default class Integer {
   public static parseString(input: string): number {
     const output = parseInt(input, 10);
 
-    if (isNaN(output)) {
-      const message: string = 'could not convert chain id to integer';
+    if (Number.isNaN(output)) {
+      const message = 'could not convert chain id to integer';
       Logger.error(message, { input });
       throw new Error(message);
     }

--- a/src/NewChain/AuxiliaryChain.ts
+++ b/src/NewChain/AuxiliaryChain.ts
@@ -1,9 +1,9 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import Web3 = require('web3');
 import * as RLP from 'rlp';
 import { ContractInteract } from '@openst/mosaic.js';
 
+import { Tx } from 'web3/eth/types';
 import CliqueGenesis from './CliqueGenesis';
 import Contracts from './Contracts';
 import Shell from '../Shell';
@@ -11,17 +11,21 @@ import Directory from '../Directory';
 import Logger from '../Logger';
 import NodeDescription from '../Node/NodeDescription';
 import GethNode from '../Node/GethNode';
-import { Tx } from 'web3/eth/types';
 import InitConfig from '../Config/InitConfig';
 import Proof from './Proof';
+
+import Web3 = require('web3');
 
 /**
  * The new auxiliary chain that shall be created.
  */
 export default class AuxiliaryChain {
   private web3: Web3;
+
   private chainDir: string;
+
   private sealer: string;
+
   private deployer: string;
 
   // The below nonces are more for documentation.
@@ -29,12 +33,19 @@ export default class AuxiliaryChain {
   // changes or a contract is added or removed.
   // Co-gateway nonce is used when calculating its expected address.
   private anchorOrganizationDeploymentNonce = 0;
+
   private anchorDeploymentNonce = 1;
+
   private coGatewayAndOstPrimeOrganizationDeploymentNonce = 2;
+
   private ostPrimeDeploymentNonce = 3;
+
   private merklePatriciaProofLibraryDeploymentNonce = 4;
+
   private messageBusDeploymentNonce = 5;
+
   private gatewayLibDeploymentNonce = 5;
+
   private coGatewayDeploymentNonce = 7;
 
   /*
@@ -74,7 +85,7 @@ export default class AuxiliaryChain {
    * sealer and a deployer that can deploy contracts. The deployer gets the initial value allocated
    * to it in the genesis file.
    */
-  public async startNewChainSealer(): Promise<{ sealer: string, deployer: string }> {
+  public async startNewChainSealer(): Promise<{ sealer: string; deployer: string }> {
     this.generateAccounts();
     this.generateChain();
     await this.startNewSealer();
@@ -82,7 +93,7 @@ export default class AuxiliaryChain {
     return {
       sealer: this.sealer,
       deployer: this.deployer,
-    }
+    };
   }
 
   /**
@@ -118,7 +129,7 @@ export default class AuxiliaryChain {
     // string leaving us with the remaining 40 characters (20 bytes) that
     // make up the address. Also adding the removed leading `0x` again.
     const expectedOstCoGatewayAddress = this.web3.utils.toChecksumAddress(
-      `0x${nonceHash.substring(26)}`
+      `0x${nonceHash.substring(26)}`,
     );
 
     return expectedOstCoGatewayAddress;
@@ -155,11 +166,11 @@ export default class AuxiliaryChain {
     hashLockSecret: string,
     proofData: Proof,
   ): Promise<{
-    anchorOrganization: ContractInteract.Organization,
-    anchor: ContractInteract.Anchor,
-    coGatewayAndOstPrimeOrganization: ContractInteract.Organization,
-    ostPrime: ContractInteract.OSTPrime,
-    ostCoGateway: ContractInteract.EIP20CoGateway,
+    anchorOrganization: ContractInteract.Organization;
+    anchor: ContractInteract.Anchor;
+    coGatewayAndOstPrimeOrganization: ContractInteract.Organization;
+    ostPrime: ContractInteract.OSTPrime;
+    ostCoGateway: ContractInteract.EIP20CoGateway;
   }> {
     const {
       anchorOrganization,
@@ -203,7 +214,7 @@ export default class AuxiliaryChain {
       this.web3,
       auxiliaryOstCoGatewayAddress,
     );
-    return ostCoGateway.progressMint(messageHash, hashLockSecret, this.txOptions)
+    return ostCoGateway.progressMint(messageHash, hashLockSecret, this.txOptions);
   }
 
   /**
@@ -214,7 +225,7 @@ export default class AuxiliaryChain {
    */
   private generateAccounts(): void {
     if (fs.existsSync(path.join(this.chainDir, 'keystore'))) {
-      const message: string = 'keystore already exists; cannot continue; delete keystore before running command again';
+      const message = 'keystore already exists; cannot continue; delete keystore before running command again';
       this.logError(message);
 
       throw new Error(message);
@@ -301,11 +312,11 @@ export default class AuxiliaryChain {
     originHeight: string,
     originStateRoot: string,
   ): Promise<{
-    anchorOrganization: ContractInteract.Organization,
-    anchor: ContractInteract.Anchor,
-    coGatewayAndOstPrimeOrganization: ContractInteract.Organization,
-    ostPrime: ContractInteract.OSTPrime,
-    ostCoGateway: ContractInteract.EIP20CoGateway,
+    anchorOrganization: ContractInteract.Organization;
+    anchor: ContractInteract.Anchor;
+    coGatewayAndOstPrimeOrganization: ContractInteract.Organization;
+    ostPrime: ContractInteract.OSTPrime;
+    ostCoGateway: ContractInteract.EIP20CoGateway;
   }> {
     this.logInfo('deploying contracts');
     const anchorOrganization = await this.deployOrganization(
@@ -334,7 +345,7 @@ export default class AuxiliaryChain {
       anchor.address,
       coGatewayAndOstPrimeOrganization.address,
       originOstGatewayAddress,
-    )
+    );
 
     this.logInfo('setting co-gateway on ost prime');
     await ostPrime.setCoGateway(ostCoGateway.address, this.txOptions);
@@ -412,7 +423,7 @@ export default class AuxiliaryChain {
       // This can be any arbitrarily high number as the gas price is zero and we do not want the
       // transaction to be limited by the gas allowance.
       gas: '10000000',
-    }
+    };
   }
 
   /**
@@ -444,7 +455,7 @@ export default class AuxiliaryChain {
       'ethereum/client-go:v1.8.23',
       '--datadir', '/chain_data',
       'init',
-      '/chain_data/genesis.json'
+      '/chain_data/genesis.json',
     ];
 
     Shell.executeDockerCommand(args);
@@ -490,7 +501,7 @@ export default class AuxiliaryChain {
     this.logInfo('reading sealer and deployer address from disk');
     const addresses: string[] = this.readAddressesFromKeystore();
     if (addresses.length !== 2) {
-      const message: string = 'did not find exactly two addresses in auxiliary keystore; aborting';
+      const message = 'did not find exactly two addresses in auxiliary keystore; aborting';
       Logger.error(message);
       throw new Error(message);
     }
@@ -556,7 +567,7 @@ export default class AuxiliaryChain {
     this.logInfo('deploying organization', { owner, admin });
     const txOptions: Tx = {
       ...this.txOptions,
-      nonce
+      nonce,
     };
     return Contracts.deployOrganization(this.web3, txOptions, owner, admin);
   }
@@ -572,7 +583,9 @@ export default class AuxiliaryChain {
   ): Promise<ContractInteract.Anchor> {
     this.logInfo(
       'deploying anchor',
-      { originChainId, initialHeight, initialStateRoot, organizationAddress },
+      {
+        originChainId, initialHeight, initialStateRoot, organizationAddress,
+      },
     );
     const txOptions: Tx = {
       ...this.txOptions,
@@ -622,7 +635,9 @@ export default class AuxiliaryChain {
   ): Promise<ContractInteract.OSTPrime> {
     this.logInfo(
       'deploying ost co-gateway',
-      { ostAddress, ostPrimeAddress, anchorAddress, organizationAddress, gatewayAddress },
+      {
+        ostAddress, ostPrimeAddress, anchorAddress, organizationAddress, gatewayAddress,
+      },
     );
     const ostPrime = Contracts.deployOstCoGateway(
       this.web3,

--- a/src/NewChain/CliqueGenesis.ts
+++ b/src/NewChain/CliqueGenesis.ts
@@ -1,4 +1,4 @@
-import Integer from "../Integer";
+import Integer from '../Integer';
 
 /**
  * A genesis file for a new clique PoA chain.
@@ -22,7 +22,7 @@ export default class CliqueGenesis {
         clique: {
           period: 3,
           epoch: 30000,
-        }
+        },
       },
       nonce: '0x0',
       timestamp: CliqueGenesis.getHexTimestamp(),
@@ -809,7 +809,7 @@ export default class CliqueGenesis {
       number: '0x0',
       gasUsed: '0x0',
       parentHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
-    }
+    };
 
     // Remove leading `0x` as it should not be present in the genesis addresses.
     deployer = CliqueGenesis.removeLeading0x(deployer);
@@ -852,5 +852,3 @@ export default class CliqueGenesis {
     return input;
   }
 }
-
-

--- a/src/NewChain/Contracts.ts
+++ b/src/NewChain/Contracts.ts
@@ -1,7 +1,8 @@
 import { ContractInteract } from '@openst/mosaic.js';
-import Web3 = require('web3');
-import Logger from '../Logger';
 import { Tx } from 'web3/eth/types';
+import Logger from '../Logger';
+
+import Web3 = require('web3');
 
 /**
  * Contracts contains methods to deploy contracts.
@@ -157,8 +158,8 @@ export default class Contracts {
     web3: Web3,
     txOptions: Tx,
   ): Promise<{
-    gatewayLib: ContractInteract.GatewayLib,
-    messageBus: ContractInteract.MessageBus,
+    gatewayLib: ContractInteract.GatewayLib;
+    messageBus: ContractInteract.MessageBus;
   }> {
     const merklePatriciaProof = await ContractInteract.MerklePatriciaProof.deploy(
       web3,
@@ -184,7 +185,7 @@ export default class Contracts {
     return {
       gatewayLib,
       messageBus,
-    }
+    };
   }
 
   /**

--- a/src/NewChain/Initialization.ts
+++ b/src/NewChain/Initialization.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import Web3 = require('web3');
 import { Utils } from '@openst/mosaic.js';
 
 import InitConfig from '../Config/InitConfig';
@@ -11,6 +10,8 @@ import NodeDescription from '../Node/NodeDescription';
 import Logger from '../Logger';
 import Proof from './Proof';
 import Directory from '../Directory';
+
+import Web3 = require('web3');
 
 /**
  * Initialization stitches together all classes and steps to create a new auxiliary chain.

--- a/src/NewChain/OriginChain.ts
+++ b/src/NewChain/OriginChain.ts
@@ -1,15 +1,17 @@
 import { ContractInteract } from '@openst/mosaic.js';
-import Web3 = require('web3');
 import InitConfig from '../Config/InitConfig';
 import Logger from '../Logger';
 import Contracts from './Contracts';
 import Integer from '../Integer';
+
+import Web3 = require('web3');
 
 /**
  * The origin chain when creating a new auxiliary chain.
  */
 export default class OriginChain {
   private chainId: string;
+
   private ostGateway: ContractInteract.EIP20Gateway;
 
   constructor(
@@ -44,10 +46,10 @@ export default class OriginChain {
     auxiliaryStateRootZero: string,
     expectedOstCoGatewayAddress: string,
   ): Promise<{
-    anchorOrganization: ContractInteract.Organization,
-    anchor: ContractInteract.Anchor,
-    ostGatewayOrganization: ContractInteract.Organization,
-    ostGateway: ContractInteract.EIP20Gateway,
+    anchorOrganization: ContractInteract.Organization;
+    anchor: ContractInteract.Anchor;
+    ostGatewayOrganization: ContractInteract.Organization;
+    ostGateway: ContractInteract.EIP20Gateway;
   }> {
     this.logInfo('deploying contracts');
 
@@ -98,7 +100,7 @@ export default class OriginChain {
   public async stake(
     auxiliaryOriginalDeployer: string,
     hashLockSecret: string,
-  ): Promise<{ blockNumber: number, stateRoot: string, messageHash: string, nonce: string }> {
+  ): Promise<{ blockNumber: number; stateRoot: string; messageHash: string; nonce: string }> {
     // First stake on the new gateway.
     const nonce = await this.ostGateway.getNonce(this.initConfig.originTxOptions.from);
     const hashLockHash = Web3.utils.sha3(hashLockSecret);
@@ -140,7 +142,7 @@ export default class OriginChain {
       stateRoot,
       messageHash,
       nonce,
-    }
+    };
   }
 
   /**
@@ -180,7 +182,9 @@ export default class OriginChain {
   ): Promise<ContractInteract.Anchor> {
     this.logInfo(
       'deploying anchor',
-      { remoteChainId, organizationAddress, blockHeight, stateRoot },
+      {
+        remoteChainId, organizationAddress, blockHeight, stateRoot,
+      },
     );
     return Contracts.deployAnchor(
       this.web3,
@@ -200,7 +204,7 @@ export default class OriginChain {
     anchorAddress: string,
     organizationAddress: string,
   ): Promise<ContractInteract.EIP20Gateway> {
-    this.logInfo('deploying ost gateway', { anchorAddress, organizationAddress })
+    this.logInfo('deploying ost gateway', { anchorAddress, organizationAddress });
     return Contracts.deployOstGateway(
       this.web3,
       this.initConfig.originTxOptions,
@@ -224,7 +228,7 @@ export default class OriginChain {
         'data',
         (blockHeader) => {
           const blockNumber = blockHeader.number;
-          numberOfBlocksToWait = numberOfBlocksToWait - 1;
+          numberOfBlocksToWait -= 1;
           this.logInfo('received block header', { blockNumber, numberOfBlocksToWait });
 
           if (numberOfBlocksToWait <= 0) {

--- a/src/NewChain/Proof.ts
+++ b/src/NewChain/Proof.ts
@@ -3,8 +3,12 @@
  */
 export default class Proof {
   readonly blockNumber: number;
+
   readonly accountData: string;
+
   readonly accountProof: string;
+
   readonly storageProof: string;
+
   readonly stateRoot: string;
 }

--- a/src/Node/GethNode.ts
+++ b/src/Node/GethNode.ts
@@ -54,7 +54,7 @@ export default class GethNode extends Node {
       ),
       {
         encoding: 'utf8',
-      }
+      },
     );
   }
 

--- a/src/Node/Node.ts
+++ b/src/Node/Node.ts
@@ -10,22 +10,31 @@ import NodeDescription from './NodeDescription';
 export default abstract class Node {
   /** The chain id identifies the chain this node should run. For example ropsten or 200. */
   protected chainId: string;
+
   /** The base directory of the mosaic chains that will hold the chains' data in a subdirectory. */
   protected mosaicDir: string;
+
   /** The directory where the chain data is store that this node will use. */
   protected chainDir: string;
+
   /** Docker will publish this port on the host. */
   protected port: number;
+
   /** Docker will publish this RPC port on the host. */
   protected rpcPort: number;
+
   /** Docker will publish this websocket port on the host. */
   protected websocketPort: number;
+
   /** The name of this docker container. */
   protected containerName: string;
+
   /** If set to true, the container is not deleted when stopped. */
   protected keepAfterStop: boolean;
+
   /** A comma separated list of addresses that get unlocked while the process is running. */
   protected unlock: string;
+
   /** The path to the password file to unlock the accounts given in unlock. */
   protected password: string;
 
@@ -97,7 +106,7 @@ export default abstract class Node {
   public ensureNetworkExists(): void {
     // `-w` in grep is used to match the exact string.
     //  Command for creating network only if network doesn't exists.
-    let createNetwork = `docker network ls | grep -w ${Node.network} || docker network create ${Node.network}`;
+    const createNetwork = `docker network ls | grep -w ${Node.network} || docker network create ${Node.network}`;
     Shell.executeInShell(createNetwork);
   }
 

--- a/src/Node/NodeDescription.ts
+++ b/src/Node/NodeDescription.ts
@@ -3,11 +3,17 @@
  */
 export default class NodeDescription {
   public mosaicDir: string = '~/.mosaic';
+
   public port: number = 30303;
+
   public rpcPort: number = 8545;
+
   public websocketPort: number = 8645;
+
   public keepAfterStop: boolean = false;
+
   public unlock: string = '';
+
   public password: string = '';
 
   constructor(readonly chainId: string) { }

--- a/src/Node/NodeFactory.ts
+++ b/src/Node/NodeFactory.ts
@@ -42,11 +42,10 @@ export default class NodeFactory {
   public static create(nodeDescription: NodeDescription): Node {
     if (NodeFactory.officialIdentifiers.includes(nodeDescription.chainId)) {
       return new ParityNode(nodeDescription);
-    } else {
-      const node = new GethNode(nodeDescription);
-      node.readBootnodes();
-
-      return node;
     }
+    const node = new GethNode(nodeDescription);
+    node.readBootnodes();
+
+    return node;
   }
 }

--- a/src/bin/NodeOptions.ts
+++ b/src/bin/NodeOptions.ts
@@ -3,7 +3,7 @@ import Directory from '../Directory';
 import Integer from '../Integer';
 
 // These defaults will be used if the relevant option is not given on the command line.
-const DEFAULT_MOSAIC_DIR = '~/.mosaic'
+const DEFAULT_MOSAIC_DIR = '~/.mosaic';
 const DEFAULT_PORT = 30303;
 const DEFAULT_RPC_PORT = 8545;
 const DEFAULT_WS_PORT = 8645;
@@ -14,16 +14,22 @@ const DEFAULT_WS_PORT = 8645;
 export default class NodeOptions {
   /** The mosaic directory to use which holds the chains' subdirectories. */
   public mosaicDir: string;
+
   /** The port of the ethereum node that docker publishes on the host. */
   public port: number;
+
   /** The rpc port of the ethereum node that docker publishes on the host. */
   public rpcPort: number;
+
   /** The websocket port of the ethereum node that docker publishes on the host. */
   public websocketPort: number;
+
   /** If set to true, the container will not be deleted when it is stopped. Defaults to false. */
   public keepAfterStop: boolean;
+
   /** A comma-separated list of accounts to unlock when starting the node. */
   public unlock: string;
+
   /**
    * Path to a password file with one line per unlocked account.
    * We have to use a password file when unlocking as we cannot provide the password on the command
@@ -35,13 +41,13 @@ export default class NodeOptions {
    * @param options The options from the command line.
    */
   constructor(options: {
-    mosaicDir: string,
-    port: string,
-    rpcPort: string,
-    websocketPort: string,
-    keepAfterStop: boolean,
-    unlock: string,
-    password: string,
+    mosaicDir: string;
+    port: string;
+    rpcPort: string;
+    websocketPort: string;
+    keepAfterStop: boolean;
+    unlock: string;
+    password: string;
   }) {
     Object.assign(this, options);
   }
@@ -74,7 +80,7 @@ export default class NodeOptions {
       port: options.port || DEFAULT_PORT,
       rpcPort: options.rpcPort || DEFAULT_RPC_PORT,
       websocketPort: options.wsPort || DEFAULT_WS_PORT,
-      keepAfterStop: options.keep ? true : false,
+      keepAfterStop: !!options.keep,
       unlock: options.unlock || '',
       password: options.password || '',
     });

--- a/src/bin/mosaic-attach.ts
+++ b/src/bin/mosaic-attach.ts
@@ -24,7 +24,7 @@ mosaic
       // within the same network (see `--network` above).
       // The port is always `8545` as that is always the same port for the nodes running *inside*
       // the containers.
-      `http://${node.getContainerName()}:8545`
+      `http://${node.getContainerName()}:8545`,
     ];
     Shell.executeDockerCommand(args);
   })

--- a/src/bin/mosaic-create.ts
+++ b/src/bin/mosaic-create.ts
@@ -37,6 +37,6 @@ mosaic.action(
     }
 
     process.exit(0);
-  }
+  },
 )
   .parse(process.argv);

--- a/src/bin/mosaic-list.ts
+++ b/src/bin/mosaic-list.ts
@@ -2,7 +2,7 @@
 
 import * as mosaic from 'commander';
 import { version } from '../../package.json';
-import Node from '../Node/Node'
+import Node from '../Node/Node';
 import Shell from '../Shell';
 
 mosaic

--- a/src/bin/mosaic-logs.ts
+++ b/src/bin/mosaic-logs.ts
@@ -3,9 +3,9 @@
 import * as mosaic from 'commander';
 import { version } from '../../package.json';
 import Shell from '../Shell';
-import Node from '../Node/Node'
-import NodeDescription from '../Node/NodeDescription'
-import NodeFactory from '../Node/NodeFactory'
+import Node from '../Node/Node';
+import NodeDescription from '../Node/NodeDescription';
+import NodeFactory from '../Node/NodeFactory';
 
 mosaic
   .version(version)

--- a/src/bin/mosaic-stop.ts
+++ b/src/bin/mosaic-stop.ts
@@ -10,7 +10,6 @@ mosaic
   .version(version)
   .arguments('<chains...>')
   .action((chainIds: string[]) => {
-
     for (const chainId of chainIds) {
       const chain: Node = NodeFactory.create(new NodeDescription(chainId));
 


### PR DESCRIPTION
I updated the eslinter config to expect 2 spaces also for TypeScript
files.

I also ran the linter with the `--fix` option.

Now that the linter is set-up correctly, it returns 83 problems that cannot be fixed by `--fix`. I
created a follow-up ticket to fix the linting and add a linter check to
travis: #64

Fixes #62