### PR TITLE
Add smoke tests to start and stop chains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # IDEs
 .idea/
 .vscode/
+*.swp
+tags
 
 # Node passwords
 password.txt

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint src -c .eslintrc.json --ext ts",
-    "test": "mocha -r ts-node/register tests/**/*.test.ts tests/*.test.ts"
+    "test": "npm run test:unit && npm run test:smoke",
+    "test:unit": "mocha -r ts-node/register tests/**/*.test.ts tests/*.test.ts",
+    "test:smoke": "./tests/smoke.sh"
   },
   "repository": {
     "type": "git",

--- a/src/bin/mosaic-start.ts
+++ b/src/bin/mosaic-start.ts
@@ -5,7 +5,6 @@ import { version } from '../../package.json';
 import NodeFactory from '../Node/NodeFactory';
 import Node from '../Node/Node';
 import NodeOptions from './NodeOptions';
-import Logger from '../Logger';
 
 let mosaic = commander
   .version(version)
@@ -17,7 +16,7 @@ mosaic
   .option('-u,--unlock <accounts>', 'a comma separated list of accounts that get unlocked in the node; you must use this together with --password')
   .option('-s,--password <file>', 'the path to the password file on your machine; you must use this together with --unlock')
   .action((chainId: string, options) => {
-    let {
+    const {
       mosaicDir,
       port,
       rpcPort,

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+#
+# This file runs some basic mosaic commands to start, list, and stop chains.
+# It asserts that the command generally works.
+#
+
+# Prints an info string to stdout.
+function info {
+    echo "INFO: $1"
+}
+
+# Prints an error string to stdout after it attempted to stop all running nodes.
+function error {
+    echo "ERROR! Aborting."
+    stop_nodes
+    echo "ERROR: $1"
+    exit 1
+}
+
+# Starts a single node.
+function start_node {
+    info "Starting node $1."
+    try_silent "./mosaic start $1" "Could not start node $1."
+}
+
+# Stops a single node.
+function stop_node {
+    info "Stopping node $1."
+    try_silent "./mosaic stop $1" "Could not stop node $1."
+}
+
+# Starts all nodes for the test.
+function start_nodes {
+    info "Starting all nodes."
+    start_node 1406
+    start_node 1407
+    start_node ropsten
+}
+
+# Stops all nodes for the test.
+function stop_nodes {
+    info "Stopping all nodes."
+    stop_node ropsten
+    stop_node 1407
+    stop_node 1406
+}
+
+# Tries a command without output. Errors if the command does not execute successfully.
+function try_silent {
+    eval $1 1>/dev/null 2>&1 || error "$2"
+}
+
+# Tries a command without outpet. Errors if the command *executes successfully.*
+function fail_silent {
+    eval $1 1>/dev/null 2>&1 && error "$2"
+}
+
+# Sets the global variable `grep_command` with the given chain.
+function set_grep_command {
+    grep_command="./mosaic list | grep mosaic_$1"
+}
+
+# Errors if the given chain is not in the output of `mosaic list`.
+function grep_try {
+    info "Checking that node $1 is listed."
+    set_grep_command $1
+    try_silent "$grep_command" "Node was expected to be running, but is not: $1."
+}
+
+# Errors if the given chain *is* in the output of `mosaic list`.
+function grep_fail {
+    info "Checking that node $1 is *not* listed."
+    set_grep_command $1
+    fail_silent "$grep_command" "Node was not expected to be running, but is: $1."
+}
+
+# Errors if an RPC connection to the node is not possible. Works only with chain IDs, not names.
+function rpc_try {
+    info "Checking RPC connection to node $1."
+    try_silent "curl -X POST -H \"Content-Type: application/json\" --data '{\"jsonrpc\":\"2.0\",\"method\":\"eth_syncing\",\"params\":[],\"id\":1}' 127.0.0.1:4$1" "Could not connect to RPC of node $1."
+}
+
+# Making sure the mosaic command exists (we are in the right directory).
+try_silent "ls mosaic" "Script must be run from the mosaic chains root directory so that the required node modules are available."
+
+# Start all nodes to test.
+start_nodes
+
+# Check that the started nodes are listed.
+grep_try 1406
+grep_try 1407
+grep_try ropsten
+
+# Try to RPC call the running nodes.
+rpc_try 1406
+rpc_try 1407
+rpc_try "0003" # Given like this as it is used for the port in `rpc_try`.
+
+# Stop and start some nodes and make sure they are or are not running.
+stop_node ropsten
+grep_fail ropsten
+
+stop_node 1407
+grep_fail 1407
+grep_try 1406
+
+start_node 1407
+grep_try 1407
+grep_try 1406
+grep_fail ropsten
+
+start_node ropsten
+grep_try ropsten
+
+# When done, stop all nodes.
+stop_nodes
+


### PR DESCRIPTION
Created a bash script that runs various mosaic chains commands and fails
if any of the commands fails.

Added a flag to run parity as the user that also runs the mosaic
command. See comment in-code for details.

Bumped parity to version `2.4.5`, as the previous tag `2.3.4` does not
exist on docker hub anymore.

Did some minor linting fixes in other files where I encountered them.

Fixes #50