### PR TITLE
Reset admin after creating new chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Troubleshooting:
   * Make sure that the newly created auxiliary sealer doesn't use any ports that you forward to any running nodes via SSH. You can use the options `--port`, `--rpc-port`, and `--ws-port` with the `create` command to make sure you use different ports on the auxiliary sealer.
 * The EVM reverts without details at the step "stake" (on origin):
   * Make sure that you set the correct OST address in you init configuration and that your origin account has sufficient funds to pay for the stake amount plus the bounty amount (on origin).
+* Your machine is showing sign of slowness after creation of auxiliary chains:
+  * Too many docker containers could be running while creation of auxiliary chains with different chain ids. Make sure you stop the docker containers of auxiliary chains if it's not being used.  
 
 ## Adding an existing auxiliary chain
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Troubleshooting:
   * Make sure that the newly created auxiliary sealer doesn't use any ports that you forward to any running nodes via SSH. You can use the options `--port`, `--rpc-port`, and `--ws-port` with the `create` command to make sure you use different ports on the auxiliary sealer.
 * The EVM reverts without details at the step "stake" (on origin):
   * Make sure that you set the correct OST address in you init configuration and that your origin account has sufficient funds to pay for the stake amount plus the bounty amount (on origin).
-* Your machine is showing sign of slowness after creation of auxiliary chains:
+* Your machine is showing sign of slowness because of creation of auxiliary chains:
   * Too many docker containers could be running while creation of auxiliary chains with different chain ids. Make sure you stop the docker containers of auxiliary chains if it's not being used.  
 
 ## Adding an existing auxiliary chain

--- a/src/NewChain/AuxiliaryChain.ts
+++ b/src/NewChain/AuxiliaryChain.ts
@@ -83,13 +83,6 @@ export default class AuxiliaryChain {
   }
 
   /**
-   * @returns The deployer address.
-   */
-  public getDeployer(): string {
-    return this.deployer;
-  }
-
-  /**
    * Generates a new chain, starts a sealer that runs the chain, and returns the addresses of the
    * sealer and a deployer that can deploy contracts. The deployer gets the initial value allocated
    * to it in the genesis file.

--- a/src/NewChain/AuxiliaryChain.ts
+++ b/src/NewChain/AuxiliaryChain.ts
@@ -224,14 +224,16 @@ export default class AuxiliaryChain {
    *
    * @param organization Auxiliary chain organization address.
    * @param txOptions Transaction options.
+   *
+   * @returns {Promise} Promise containing transaction receipt.
    */
   public async resetOrganizationAdmin(
     organization,
     txOptions,
-  ): Promise<void> {
+  ): Promise<Object> {
     this.logInfo('reseting auxiliary chain organization admin.', { organization, txOptions } );
     const contractInstance = new MosaicContracts(undefined, this.web3);
-    const tx = contractInstance.AuxiliaryOrganization(organization )
+    const tx = contractInstance.AuxiliaryOrganization(organization)
           .methods.setAdmin('0x0000000000000000000000000000000000000000');
     return tx.send(txOptions);
   }

--- a/src/NewChain/AuxiliaryChain.ts
+++ b/src/NewChain/AuxiliaryChain.ts
@@ -232,6 +232,8 @@ export default class AuxiliaryChain {
     txOptions,
   ): Promise<Object> {
     this.logInfo('reseting auxiliary chain organization admin.', { organization, txOptions } );
+    // ContractInteract.Organization doesn't implement setAdmin function in mosaic.js.
+    // That's why MosaicContracts being used here.
     const contractInstance = new MosaicContracts(undefined, this.web3);
     const tx = contractInstance.AuxiliaryOrganization(organization)
           .methods.setAdmin('0x0000000000000000000000000000000000000000');

--- a/src/NewChain/AuxiliaryChain.ts
+++ b/src/NewChain/AuxiliaryChain.ts
@@ -83,6 +83,13 @@ export default class AuxiliaryChain {
   }
 
   /**
+   * @returns The deployer address.
+   */
+  public getDeployer(): string {
+    return this.deployer;
+  }
+
+  /**
    * Generates a new chain, starts a sealer that runs the chain, and returns the addresses of the
    * sealer and a deployer that can deploy contracts. The deployer gets the initial value allocated
    * to it in the genesis file.
@@ -223,15 +230,15 @@ export default class AuxiliaryChain {
    * Resets organization contracts admin address to 0x.
    *
    * @param organization Auxiliary chain organization address.
-   * @param owner Auxiliary chain organization owner.
+   * @param from From address which will do the transaction.
    */
   public async resetOrganizationAdmin(
     organization,
-    owner,
+    from,
   ): Promise<void> {
     this.logInfo('reseting auxiliary chain organization admin.');
     const contractInstance = new MosaicContracts(undefined, this.web3);
-    const auxiliaryTxOptions = { from: owner };
+    const auxiliaryTxOptions = { from: from };
     await contractInstance.AuxiliaryOrganization(organization, auxiliaryTxOptions )
           .methods.setAdmin('0x0000000000000000000000000000000000000000');
   }

--- a/src/NewChain/AuxiliaryChain.ts
+++ b/src/NewChain/AuxiliaryChain.ts
@@ -223,16 +223,15 @@ export default class AuxiliaryChain {
    * Resets organization contracts admin address to 0x.
    *
    * @param organization Auxiliary chain organization address.
-   * @param from From address which will do the transaction.
+   * @param txOptions Transaction options.
    */
   public async resetOrganizationAdmin(
     organization,
-    from,
+    txOptions,
   ): Promise<void> {
-    this.logInfo('reseting auxiliary chain organization admin.');
+    this.logInfo('reseting auxiliary chain organization admin.', { organization, txOptions } );
     const contractInstance = new MosaicContracts(undefined, this.web3);
-    const auxiliaryTxOptions = { from: from };
-    await contractInstance.AuxiliaryOrganization(organization, auxiliaryTxOptions )
+    await contractInstance.AuxiliaryOrganization(organization, txOptions )
           .methods.setAdmin('0x0000000000000000000000000000000000000000');
   }
 

--- a/src/NewChain/AuxiliaryChain.ts
+++ b/src/NewChain/AuxiliaryChain.ts
@@ -220,7 +220,7 @@ export default class AuxiliaryChain {
   }
 
   /**
-   * Resets organization contracts admin address to 0x.
+   * Resets organization contracts admin address to `address(0)`.
    *
    * @param organization Auxiliary chain organization address.
    * @param txOptions Transaction options.

--- a/src/NewChain/AuxiliaryChain.ts
+++ b/src/NewChain/AuxiliaryChain.ts
@@ -231,8 +231,9 @@ export default class AuxiliaryChain {
   ): Promise<void> {
     this.logInfo('reseting auxiliary chain organization admin.', { organization, txOptions } );
     const contractInstance = new MosaicContracts(undefined, this.web3);
-    await contractInstance.AuxiliaryOrganization(organization, txOptions )
+    const tx = contractInstance.AuxiliaryOrganization(organization )
           .methods.setAdmin('0x0000000000000000000000000000000000000000');
+    return tx.send(txOptions);
   }
 
   /**

--- a/src/NewChain/AuxiliaryChain.ts
+++ b/src/NewChain/AuxiliaryChain.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as RLP from 'rlp';
-import { ContractInteract } from '@openst/mosaic.js';
+import { ContractInteract, Contracts as MosaicContracts } from '@openst/mosaic.js';
 
 import { Tx } from 'web3/eth/types';
 import CliqueGenesis from './CliqueGenesis';
@@ -217,6 +217,21 @@ export default class AuxiliaryChain {
       auxiliaryOstCoGatewayAddress,
     );
     return ostCoGateway.progressMint(messageHash, hashLockSecret, this.txOptions);
+  }
+
+  /**
+   * Resets organization contracts admin address to 0x.
+   *
+   * @param auxiliaryOrganization Auxiliary chain organization address.
+   */
+  public async resetOrganizationAdmin(
+    auxiliaryOrganization,
+  ): Promise<void> {
+    this.logInfo('reseting auxiliary chain organization admin.');
+    const contractInstance = new MosaicContracts(undefined, this.web3);
+    const auxiliaryTxOptions = { from: this.initConfig.auxiliaryAnchorOrganizationOwner };
+    await contractInstance.AuxiliaryOrganization(auxiliaryOrganization, auxiliaryTxOptions )
+          .methods.setAdmin('0x');
   }
 
   /**

--- a/src/NewChain/AuxiliaryChain.ts
+++ b/src/NewChain/AuxiliaryChain.ts
@@ -222,16 +222,18 @@ export default class AuxiliaryChain {
   /**
    * Resets organization contracts admin address to 0x.
    *
-   * @param auxiliaryOrganization Auxiliary chain organization address.
+   * @param organization Auxiliary chain organization address.
+   * @param owner Auxiliary chain organization owner.
    */
   public async resetOrganizationAdmin(
-    auxiliaryOrganization,
+    organization,
+    owner,
   ): Promise<void> {
     this.logInfo('reseting auxiliary chain organization admin.');
     const contractInstance = new MosaicContracts(undefined, this.web3);
-    const auxiliaryTxOptions = { from: this.initConfig.auxiliaryAnchorOrganizationOwner };
-    await contractInstance.AuxiliaryOrganization(auxiliaryOrganization, auxiliaryTxOptions )
-          .methods.setAdmin('0x');
+    const auxiliaryTxOptions = { from: owner };
+    await contractInstance.AuxiliaryOrganization(organization, auxiliaryTxOptions )
+          .methods.setAdmin('0x0000000000000000000000000000000000000000');
   }
 
   /**

--- a/src/NewChain/Initialization.ts
+++ b/src/NewChain/Initialization.ts
@@ -172,6 +172,11 @@ export default class Initialization {
       ),
     ]);
 
+    await Promise.all([
+      originChain.resetOrganizationAdmin(originAnchorOrganization.address),
+      auxiliaryChain.resetOrganizationAdmin(anchorOrganization.address),
+    ]);
+
     mosaicConfig.writeToUtilityChainDirectory();
   }
 

--- a/src/NewChain/Initialization.ts
+++ b/src/NewChain/Initialization.ts
@@ -174,8 +174,8 @@ export default class Initialization {
       ),
     ]);
 
-    // Resets ostGateway organization admin address in origin chain as deployer is admin here.
-    // Resets coGatewayAndOstPrime organization admin address in aux chain as deployer is admin here.
+    // Resets ostGateway organization admin address to 0x in origin chain as deployer is admin here.
+    // Resets coGatewayAndOstPrime organization admin to 0x address in aux chain as deployer is admin here.
     await Promise.all([
       originChain.resetOrganizationAdmin(
         ostGatewayOrganization.address,

--- a/src/NewChain/Initialization.ts
+++ b/src/NewChain/Initialization.ts
@@ -59,6 +59,7 @@ export default class Initialization {
       originChain,
       auxiliaryChain,
       hashLockSecret,
+      initConfig,
     );
 
     Logger.warn(
@@ -93,6 +94,7 @@ export default class Initialization {
     originChain: OriginChain,
     auxiliaryChain: AuxiliaryChain,
     hashLockSecret: string,
+    initConfig: InitConfig,
   ): Promise<void> {
     Initialization.initializeDataDir(auxiliaryNodeDescription.mosaicDir);
     mosaicConfig.auxiliaryChainId = auxiliaryNodeDescription.chainId;
@@ -173,8 +175,10 @@ export default class Initialization {
     ]);
 
     await Promise.all([
-      originChain.resetOrganizationAdmin(originAnchorOrganization.address),
-      auxiliaryChain.resetOrganizationAdmin(anchorOrganization.address),
+      originChain.resetOrganizationAdmin(originAnchorOrganization.address, initConfig.originAnchorOrganizationOwner),
+      originChain.resetOrganizationAdmin(ostGatewayOrganization.address, initConfig.originGatewayOrganizationOwner),
+      auxiliaryChain.resetOrganizationAdmin(anchorOrganization.address, initConfig.auxiliaryAnchorOrganizationOwner),
+      auxiliaryChain.resetOrganizationAdmin(coGatewayAndOstPrimeOrganization.address, initConfig.auxiliaryCoGatewayAndOstPrimeOrganizationOwner),
     ]);
 
     mosaicConfig.writeToUtilityChainDirectory();

--- a/src/NewChain/Initialization.ts
+++ b/src/NewChain/Initialization.ts
@@ -174,11 +174,17 @@ export default class Initialization {
       ),
     ]);
 
-    // Resets ostGateway organization admin address in origin chain as admin is deployer here.
-    // Resets coGatewayAndOstPrime organization admin address in aux chain as admin is deployer here.
+    // Resets ostGateway organization admin address in origin chain as deployer is admin here.
+    // Resets coGatewayAndOstPrime organization admin address in aux chain as deployer is admin here.
     await Promise.all([
-      originChain.resetOrganizationAdmin(ostGatewayOrganization.address, initConfig.originTxOptions.from),
-      auxiliaryChain.resetOrganizationAdmin(coGatewayAndOstPrimeOrganization.address, deployer),
+      originChain.resetOrganizationAdmin(
+        ostGatewayOrganization.address,
+        { from: initConfig.originTxOptions.from },
+        ),
+      auxiliaryChain.resetOrganizationAdmin(
+        coGatewayAndOstPrimeOrganization.address,
+        { from: deployer },
+        ),
     ]);
 
     mosaicConfig.writeToUtilityChainDirectory();

--- a/src/NewChain/Initialization.ts
+++ b/src/NewChain/Initialization.ts
@@ -178,7 +178,7 @@ export default class Initialization {
     // Resets coGatewayAndOstPrime organization admin address in aux chain as admin is deployer here.
     await Promise.all([
       originChain.resetOrganizationAdmin(ostGatewayOrganization.address, initConfig.originTxOptions.from),
-      auxiliaryChain.resetOrganizationAdmin(coGatewayAndOstPrimeOrganization.address, auxiliaryChain.getDeployer()),
+      auxiliaryChain.resetOrganizationAdmin(coGatewayAndOstPrimeOrganization.address, deployer),
     ]);
 
     mosaicConfig.writeToUtilityChainDirectory();

--- a/src/NewChain/Initialization.ts
+++ b/src/NewChain/Initialization.ts
@@ -174,11 +174,11 @@ export default class Initialization {
       ),
     ]);
 
+    // Resets ostGateway organization admin address in origin chain as admin is deployer here.
+    // Resets coGatewayAndOstPrime organization admin address in aux chain as admin is deployer here.
     await Promise.all([
-      originChain.resetOrganizationAdmin(originAnchorOrganization.address, initConfig.originAnchorOrganizationOwner),
-      originChain.resetOrganizationAdmin(ostGatewayOrganization.address, initConfig.originGatewayOrganizationOwner),
-      auxiliaryChain.resetOrganizationAdmin(anchorOrganization.address, initConfig.auxiliaryAnchorOrganizationOwner),
-      auxiliaryChain.resetOrganizationAdmin(coGatewayAndOstPrimeOrganization.address, initConfig.auxiliaryCoGatewayAndOstPrimeOrganizationOwner),
+      originChain.resetOrganizationAdmin(ostGatewayOrganization.address, initConfig.originTxOptions.from),
+      auxiliaryChain.resetOrganizationAdmin(coGatewayAndOstPrimeOrganization.address, auxiliaryChain.getDeployer()),
     ]);
 
     mosaicConfig.writeToUtilityChainDirectory();

--- a/src/NewChain/Initialization.ts
+++ b/src/NewChain/Initialization.ts
@@ -59,7 +59,13 @@ export default class Initialization {
       originChain,
       auxiliaryChain,
       hashLockSecret,
-      initConfig,
+    );
+
+    await Initialization.resetOrganizationAdmins(
+      mosaicConfig,
+      originChain,
+      auxiliaryChain,
+      initConfig.originTxOptions.from,
     );
 
     Logger.warn(
@@ -94,7 +100,6 @@ export default class Initialization {
     originChain: OriginChain,
     auxiliaryChain: AuxiliaryChain,
     hashLockSecret: string,
-    initConfig: InitConfig,
   ): Promise<void> {
     Initialization.initializeDataDir(auxiliaryNodeDescription.mosaicDir);
     mosaicConfig.auxiliaryChainId = auxiliaryNodeDescription.chain;
@@ -174,20 +179,36 @@ export default class Initialization {
       ),
     ]);
 
-    // Resets ostGateway organization admin address to 0x in origin chain as deployer is admin here.
-    // Resets coGatewayAndOstPrime organization admin to 0x address in aux chain as deployer is admin here.
+    mosaicConfig.writeToUtilityChainDirectory();
+  }
+
+  /**
+   * Resets ostGateway organization admin address to `address(0)` in origin chain as deployer is admin here.
+   * Resets coGatewayAndOstPrime organization admin to `address(0)` in aux chain as deployer is admin here.
+   *
+   * @param mosaicConfig Object holds the chain ids and addresses of a mosaic chain.
+   * @param {OriginChain} originChain OriginChain instance.
+   * @param {AuxiliaryChain} auxiliaryChain AuxiliaryChain instance.
+   * @param {string} originOstGatewayOrganizationAdmin Gateway organization contract admin.
+   *
+   * @returns {Promise<void>}
+   */
+  private static async resetOrganizationAdmins(
+    mosaicConfig,
+    originChain: OriginChain,
+    auxiliaryChain: AuxiliaryChain,
+    originOrganizationAdmin: string,
+  ): Promise<void> {
     await Promise.all([
       originChain.resetOrganizationAdmin(
-        ostGatewayOrganization.address,
-        { from: initConfig.originTxOptions.from },
-        ),
+        mosaicConfig.originOstGatewayOrganizationAddress,
+        { from: originOrganizationAdmin },
+      ),
       auxiliaryChain.resetOrganizationAdmin(
-        coGatewayAndOstPrimeOrganization.address,
-        { from: deployer },
-        ),
+        mosaicConfig.auxiliaryCoGatewayAndOstPrimeOrganizationAddress,
+        { from: mosaicConfig.auxiliaryOriginalDeployer },
+      ),
     ]);
-
-    mosaicConfig.writeToUtilityChainDirectory();
   }
 
   /**

--- a/src/NewChain/Initialization.ts
+++ b/src/NewChain/Initialization.ts
@@ -194,7 +194,7 @@ export default class Initialization {
    * @returns {Promise<void>}
    */
   private static async resetOrganizationAdmins(
-    mosaicConfig,
+    mosaicConfig: MosaicConfig,
     originChain: OriginChain,
     auxiliaryChain: AuxiliaryChain,
     originOrganizationAdmin: string,

--- a/src/NewChain/OriginChain.ts
+++ b/src/NewChain/OriginChain.ts
@@ -66,7 +66,7 @@ export default class OriginChain {
       auxiliaryStateRootZero,
     );
 
-    // Owner of the organization has to be the deployer, as we need to be able to activate the
+    // Admin of the organization has to be the deployer, as we need to be able to activate the
     // gateway
     const ostGatewayOrganization = await this.deployOrganization(
       this.initConfig.originGatewayOrganizationOwner,

--- a/src/NewChain/OriginChain.ts
+++ b/src/NewChain/OriginChain.ts
@@ -1,4 +1,4 @@
-import { ContractInteract } from '@openst/mosaic.js';
+import { ContractInteract, Contracts as MosaicContracts } from '@openst/mosaic.js';
 import InitConfig from '../Config/InitConfig';
 import Logger from '../Logger';
 import Contracts from './Contracts';
@@ -159,6 +159,21 @@ export default class OriginChain {
       auxiliaryOstCoGatewayAddress,
     );
     return ostGateway.progressStake(messageHash, hashLockSecret, this.initConfig.originTxOptions);
+  }
+
+  /**
+   * Resets organization contracts admin address to 0x.
+   *
+   * @param originOrganization Origin chain organization address.
+   */
+  public async resetOrganizationAdmin(
+    originOrganization,
+  ): Promise<void> {
+    this.logInfo('reseting origin chain organization admin.');
+    const contractInstance = new MosaicContracts(this.web3, null);
+    const originTxOptions = { from: this.initConfig.originAnchorOrganizationOwner };
+    return contractInstance.OriginOrganization(originOrganization, originTxOptions )
+           .methods.setAdmin('0x');
   }
 
   /**

--- a/src/NewChain/OriginChain.ts
+++ b/src/NewChain/OriginChain.ts
@@ -173,8 +173,9 @@ export default class OriginChain {
   ): Promise<void> {
     this.logInfo("reseting origin chain organization admin", { organization, txOptions } );
     const contractInstance = new MosaicContracts(this.web3, null);
-    await contractInstance.OriginOrganization(organization, txOptions )
+    const tx = contractInstance.OriginOrganization(organization )
            .methods.setAdmin('0x0000000000000000000000000000000000000000');
+    return tx.send(txOptions);
   }
 
   /**

--- a/src/NewChain/OriginChain.ts
+++ b/src/NewChain/OriginChain.ts
@@ -164,16 +164,19 @@ export default class OriginChain {
   /**
    * Resets organization contracts admin address to 0x.
    *
-   * @param originOrganization Origin chain organization address.
+   * @param organization Origin chain organization address.
+   * @param owner Origin chain organization owner.
    */
   public async resetOrganizationAdmin(
-    originOrganization,
+    organization,
+    owner,
   ): Promise<void> {
-    this.logInfo('reseting origin chain organization admin.');
+    this.logInfo("reseting origin chain organization admin", { organization, owner });
     const contractInstance = new MosaicContracts(this.web3, null);
-    const originTxOptions = { from: this.initConfig.originAnchorOrganizationOwner };
-    return contractInstance.OriginOrganization(originOrganization, originTxOptions )
-           .methods.setAdmin('0x');
+    const originTxOptions = { from: owner };
+    const oldAdmin = await contractInstance.OriginOrganization(organization, originTxOptions ).methods.admin().call();
+    await contractInstance.OriginOrganization(organization, originTxOptions )
+           .methods.setAdmin('0x0000000000000000000000000000000000000000');
   }
 
   /**

--- a/src/NewChain/OriginChain.ts
+++ b/src/NewChain/OriginChain.ts
@@ -166,14 +166,16 @@ export default class OriginChain {
    *
    * @param organization Origin chain organization address.
    * @param txOptions Transaction options.
+   *
+   * @returns {Promise} Promise containing transaction receipt.
    */
   public async resetOrganizationAdmin(
     organization,
     txOptions,
-  ): Promise<void> {
+  ): Promise<Object> {
     this.logInfo("reseting origin chain organization admin", { organization, txOptions } );
     const contractInstance = new MosaicContracts(this.web3, null);
-    const tx = contractInstance.OriginOrganization(organization )
+    const tx = contractInstance.OriginOrganization(organization)
            .methods.setAdmin('0x0000000000000000000000000000000000000000');
     return tx.send(txOptions);
   }

--- a/src/NewChain/OriginChain.ts
+++ b/src/NewChain/OriginChain.ts
@@ -165,16 +165,15 @@ export default class OriginChain {
    * Resets organization contracts admin address to 0x.
    *
    * @param organization Origin chain organization address.
-   * @param from From address which will do the transaction.
+   * @param txOptions Transaction options.
    */
   public async resetOrganizationAdmin(
     organization,
-    from,
+    txOptions,
   ): Promise<void> {
-    this.logInfo("reseting origin chain organization admin", { organization, from });
+    this.logInfo("reseting origin chain organization admin", { organization, txOptions } );
     const contractInstance = new MosaicContracts(this.web3, null);
-    const originTxOptions = { from: from };
-    await contractInstance.OriginOrganization(organization, originTxOptions )
+    await contractInstance.OriginOrganization(organization, txOptions )
            .methods.setAdmin('0x0000000000000000000000000000000000000000');
   }
 

--- a/src/NewChain/OriginChain.ts
+++ b/src/NewChain/OriginChain.ts
@@ -162,7 +162,7 @@ export default class OriginChain {
   }
 
   /**
-   * Resets organization contracts admin address to 0x.
+   * Resets organization contracts admin address to `address(0)`.
    *
    * @param organization Origin chain organization address.
    * @param txOptions Transaction options.

--- a/src/NewChain/OriginChain.ts
+++ b/src/NewChain/OriginChain.ts
@@ -174,6 +174,8 @@ export default class OriginChain {
     txOptions,
   ): Promise<Object> {
     this.logInfo("reseting origin chain organization admin", { organization, txOptions } );
+    // ContractInteract.Organization doesn't implement setAdmin function in mosaic.js.
+    // That's why MosaicContracts being used here.
     const contractInstance = new MosaicContracts(this.web3, null);
     const tx = contractInstance.OriginOrganization(organization)
            .methods.setAdmin('0x0000000000000000000000000000000000000000');

--- a/src/NewChain/OriginChain.ts
+++ b/src/NewChain/OriginChain.ts
@@ -165,16 +165,15 @@ export default class OriginChain {
    * Resets organization contracts admin address to 0x.
    *
    * @param organization Origin chain organization address.
-   * @param owner Origin chain organization owner.
+   * @param from From address which will do the transaction.
    */
   public async resetOrganizationAdmin(
     organization,
-    owner,
+    from,
   ): Promise<void> {
-    this.logInfo("reseting origin chain organization admin", { organization, owner });
+    this.logInfo("reseting origin chain organization admin", { organization, from });
     const contractInstance = new MosaicContracts(this.web3, null);
-    const originTxOptions = { from: owner };
-    const oldAdmin = await contractInstance.OriginOrganization(organization, originTxOptions ).methods.admin().call();
+    const originTxOptions = { from: from };
     await contractInstance.OriginOrganization(organization, originTxOptions )
            .methods.setAdmin('0x0000000000000000000000000000000000000000');
   }


### PR DESCRIPTION
- In origin chain deployer is admin of ostGateway organization address.
  In Aux chain deployer is admin of coGatewayAndOstPrime organization address.
  So only above two organization contract admins needs to be reseted.

- Anchor organization admins in both chains doesn't need to be resetted as they are specified.

- Tested the code by creating new chain and verifying the reseting of respective organization admin.

Fixes #32 