### PR TITLE
Publish mosaic chains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ tags
 # Node passwords
 password.txt
 
+# Packaging output
+lib/
+
 # Initialization configs for new chains; keep example
 initialize/*.json
 !initialize/example.json

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@ tags
 password.txt
 
 # Packaging output
-lib/
+lib/**
+openst-mosaic-chains-*.tgz
 
 # Initialization configs for new chains; keep example
 initialize/*.json

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,15 @@
+import Directory from './src/Directory';
+import Logger from './src/Logger';
+import Node from './src/Node/Node';
+import NodeDescription from './src/Node/NodeDescription';
+import NodeFactory from './src/Node/NodeFactory';
+import Shell from './src/Shell';
+
+module.exports = {
+  Directory,
+  Logger,
+  Node,
+  NodeDescription,
+  NodeFactory,
+  Shell,
+};

--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,7 @@ import NodeDescription from './src/Node/NodeDescription';
 import NodeFactory from './src/Node/NodeFactory';
 import Shell from './src/Shell';
 
-module.exports = {
+export {
   Directory,
   Logger,
   Node,

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,24 +25,24 @@
       }
     },
     "@openst/mosaic-contracts": {
-      "version": "0.10.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@openst/mosaic-contracts/-/mosaic-contracts-0.10.0-rc.1.tgz",
-      "integrity": "sha512-Jx0AGmEPxLES0I9b3arQ83oB1jcxXbz+clvgzWAo9EY8l0y6ITU6kueVkO+GY5PbB37TniwOBupTcKxWk5+ovw=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@openst/mosaic-contracts/-/mosaic-contracts-0.10.0.tgz",
+      "integrity": "sha512-KPMv/1Pl6Ug8VJuaUgl0sZkYWiMU3bjMm9ZNSo83QAAdGo70HISVHt23sNzyJr7tgNWOxIC9GNnItAow7gktPQ=="
     },
     "@openst/mosaic.js": {
-      "version": "0.10.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@openst/mosaic.js/-/mosaic.js-0.10.0-beta.5.tgz",
-      "integrity": "sha512-c+HJIXVKkoYyUBabevp5TK9hMWwrbKxPrEr+U947Vwf62aV2kjWaRw59AWZ9opa9cp9aJ1Db9omJ4lrrXgLcRA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@openst/mosaic.js/-/mosaic.js-0.10.0.tgz",
+      "integrity": "sha512-jch9vAdBSk03cJa6Wgvumz51/XiIYALfjDW3nrsf5T3p++bsf8h+shgC84SFwdnGyh7vHqfF6AjdgncKWBAQyg==",
       "requires": {
-        "@openst/mosaic-contracts": "^0.10.0-rc.1",
+        "@openst/mosaic-contracts": ">=0.10.0 <0.11.0",
         "bn.js": "4.11.8",
         "js-scrypt": "^0.2.0"
       }
     },
     "@types/bn.js": {
-      "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.4.tgz",
-      "integrity": "sha512-AO8WW+aRcKWKQAYTfKLzwnpL6U+TfPqS+haRrhCy5ff04Da8WZud3ZgVjspQXaEXJDcTlsjUEVvL39wegDek5w==",
+      "version": "4.11.5",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.5.tgz",
+      "integrity": "sha512-AEAZcIZga0JgVMHNtl1CprA/hXX7/wPt79AgR4XqaDt7jyj3QWYw6LPoOiznPtugDmlubUnAahMs2PFxGcQrng==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -55,9 +55,9 @@
       "dev": true
     },
     "@types/fs-extra": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.5.tgz",
-      "integrity": "sha512-w7iqhDH9mN8eLClQOYTkhdYUOSpp25eXxfc6VbFOGtzxW34JcvctH2bKjj4jD4++z4R5iO5D+pg48W2e03I65A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
+      "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -70,15 +70,15 @@
       "dev": true
     },
     "@types/node": {
-      "version": "11.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.3.tgz",
-      "integrity": "sha512-wp6IOGu1lxsfnrD+5mX6qwSwWuqsdkKKxTN4aQc4wByHAKZJf9/D4KXPQ1POUjEbnCP5LMggB0OEFNY9OTsMqg==",
+      "version": "11.13.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.11.tgz",
+      "integrity": "sha512-blLeR+KIy26km1OU8yTLUlSyVCOvT6+wPq/77tIA+uSHHa4yYQosn+bbaJqPtWId0wjVClUtD7aXzDbZeKWqig==",
       "dev": true
     },
     "@types/underscore": {
-      "version": "1.8.13",
-      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.8.13.tgz",
-      "integrity": "sha512-2YEdDHTYAv3YmSoQofzFnlWYDAAtMtVcQ0lOHoURuCt1aT9OgxhhjRRU1WVAiLchNWM7B3a8/iomxenfr9TwKA==",
+      "version": "1.8.18",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.8.18.tgz",
+      "integrity": "sha512-mXQ8u416FWMPjp2zWrcVmOZtzKQM6IeyVcuE+RGF/04JLBrMjfnmNKn74VN8fIkFzU97TpzkP0ny0p0h65eC7w==",
       "dev": true
     },
     "@types/web3": {
@@ -92,55 +92,45 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.5.0.tgz",
-      "integrity": "sha512-TZ5HRDFz6CswqBUviPX8EfS+iOoGbclYroZKT3GWGYiGScX0qo6QjHc5uuM7JN920voP2zgCkHgF5SDEVlCtjQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.9.0.tgz",
+      "integrity": "sha512-FOgfBorxjlBGpDIw+0LaZIXRX6GEEUfzj8LXwaQIUCp+gDOvkI+1WgugJ7SmWiISqK9Vj5r8S7NDKO/LB+6X9A==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/parser": "1.5.0",
-        "@typescript-eslint/typescript-estree": "1.5.0",
+        "@typescript-eslint/experimental-utils": "1.9.0",
+        "@typescript-eslint/parser": "1.9.0",
+        "eslint-utils": "^1.3.1",
+        "functional-red-black-tree": "^1.0.1",
+        "regexpp": "^2.0.1",
         "requireindex": "^1.2.0",
         "tsutils": "^3.7.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/parser": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.5.0.tgz",
-          "integrity": "sha512-pRWTnJrnxuT0ragdY26hZL+bxqDd4liMlftpH2CBlMPryOIOb1J+MdZuw6R4tIu6bWVdwbHKPTs+Q34LuGvfGw==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/typescript-estree": "1.5.0",
-            "eslint-scope": "^4.0.0",
-            "eslint-visitor-keys": "^1.0.0"
-          }
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.5.0.tgz",
-          "integrity": "sha512-XqR14d4BcYgxcrpxIwcee7UEjncl9emKc/MgkeUfIk2u85KlsGYyaxC7Zxjmb17JtWERk/NaO+KnBsqgpIXzwA==",
-          "dev": true,
-          "requires": {
-            "lodash.unescape": "4.0.1",
-            "semver": "5.5.0"
-          }
-        }
+      }
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.9.0.tgz",
+      "integrity": "sha512-1s2dY9XxBwtS9IlSnRIlzqILPyeMly5tz1bfAmQ84Ul687xBBve5YsH5A5EKeIcGurYYqY2w6RkHETXIwnwV0A==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/typescript-estree": "1.9.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.4.2.tgz",
-      "integrity": "sha512-OqLkY9295DXXaWToItUv3olO2//rmzh6Th6Sc7YjFFEpEuennsm5zhygLLvHZjPxPlzrQgE8UDaOPurDylaUuw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.9.0.tgz",
+      "integrity": "sha512-CWgC1XrQ34H/+LwAU7vY5xteZDkNqeAkeidEpJnJgkKu0yqQ3ZhQ7S+dI6MX4vmmM1TKRbOrKuXc6W0fIHhdbA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "1.4.2",
+        "@typescript-eslint/experimental-utils": "1.9.0",
+        "@typescript-eslint/typescript-estree": "1.9.0",
         "eslint-scope": "^4.0.0",
         "eslint-visitor-keys": "^1.0.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.4.2.tgz",
-      "integrity": "sha512-wKgi/w6k1v3R4b6oDc20cRWro2gBzp0wn6CAeYC8ExJMfvXMfiaXzw2tT9ilxdONaVWMCk7B9fMdjos7bF/CWw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.9.0.tgz",
+      "integrity": "sha512-7Eg0TEQpCkTsEwsl1lIzd6i7L3pJLQFWesV08dS87bNz0NeSjbL78gNAP1xCKaCejkds4PhpLnZkaAjx9SU8OA==",
       "dev": true,
       "requires": {
         "lodash.unescape": "4.0.1",
@@ -323,30 +313,6 @@
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "block-stream": {
@@ -358,9 +324,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
+      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw=="
     },
     "bn.js": {
       "version": "4.11.8",
@@ -382,21 +348,6 @@
         "qs": "6.7.0",
         "raw-body": "2.4.0",
         "type-is": "~1.6.17"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
       }
     },
     "brace-expansion": {
@@ -675,9 +626,9 @@
       "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
     },
     "colorspace": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.1.tgz",
-      "integrity": "sha512-pI3btWyiuz7Ken0BWh9Elzsmv2bM9AhA7psXib4anUXy/orfZ/E0MbQwhSOG/9L8hLlalqrU0UhOuqxW1YjmVw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
       "requires": {
         "color": "3.0.x",
         "text-hex": "1.0.x"
@@ -692,9 +643,9 @@
       }
     },
     "commander": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -823,12 +774,11 @@
       }
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.0.0"
       }
     },
     "decamelize": {
@@ -1177,6 +1127,21 @@
         "text-table": "^0.2.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
         "semver": {
           "version": "5.7.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
@@ -1204,50 +1169,16 @@
       "requires": {
         "debug": "^2.6.9",
         "resolve": "^1.5.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
       }
     },
     "eslint-module-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
-      "integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
+      "integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
       "dev": true,
       "requires": {
         "debug": "^2.6.8",
         "pkg-dir": "^2.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
       }
     },
     "eslint-plugin-import": {
@@ -1268,15 +1199,6 @@
         "resolve": "^1.6.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "doctrine": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
@@ -1286,12 +1208,6 @@
             "esutils": "^2.0.2",
             "isarray": "^1.0.0"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
@@ -1516,12 +1432,23 @@
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
       }
     },
     "express": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
-      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.0.tgz",
+      "integrity": "sha512-1Z7/t3Z5ZnBG252gKUPyItc4xdeaA0X934ca2ewckAsVsw9EG71i++ZHZPYnus8g/s5Bty8IMpSVEuRkmwwPRQ==",
       "requires": {
         "accepts": "~1.3.7",
         "array-flatten": "1.1.1",
@@ -1553,21 +1480,6 @@
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
       }
     },
     "extend": {
@@ -1660,21 +1572,6 @@
         "parseurl": "~1.3.3",
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
       }
     },
     "find-up": {
@@ -1835,13 +1732,9 @@
       "dev": true
     },
     "get-stream": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "dev": true,
-      "requires": {
-        "pump": "^3.0.0"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "getpass": {
       "version": "0.1.7",
@@ -1852,9 +1745,9 @@
       }
     },
     "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1898,13 +1791,6 @@
         "timed-out": "^4.0.0",
         "url-parse-lax": "^1.0.0",
         "url-to-options": "^1.0.1"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-        }
       }
     },
     "graceful-fs": {
@@ -2319,9 +2205,9 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsonc-parser": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.0.3.tgz",
-      "integrity": "sha512-WJi9y9ABL01C8CxTKxRRQkkSpY/x2bo4Gy0WuiZGrInxQqgxQpvkBCLNcDYcHOSdhx4ODgbFcgAvfL49C+PHgQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.1.0.tgz",
+      "integrity": "sha512-n9GrT8rrr2fhvBbANa1g+xFmgGK5X91KFeDwlKQ3+SJfmH5+tKv/M/kahx/TXOMflfWHKGKqKyfHQaLKTNzJ6w==",
       "dev": true
     },
     "jsonfile": {
@@ -2431,6 +2317,13 @@
         "fecha": "^2.3.3",
         "ms": "^2.1.1",
         "triple-beam": "^1.3.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "lowercase-keys": {
@@ -2645,14 +2538,18 @@
             "locate-path": "^3.0.0"
           }
         },
-        "js-yaml": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "locate-path": {
@@ -2664,6 +2561,12 @@
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
           }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
         },
         "p-limit": {
           "version": "2.2.0",
@@ -2711,9 +2614,9 @@
       "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k="
     },
     "ms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -2830,9 +2733,9 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
-      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
       "version": "4.1.0",
@@ -3171,9 +3074,9 @@
       }
     },
     "psl": {
-      "version": "1.1.32",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
-      "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g=="
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -3278,13 +3181,17 @@
       }
     },
     "readable-stream": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-      "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "regexpp": {
@@ -3346,9 +3253,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -3406,9 +3313,9 @@
       }
     },
     "rxjs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
-      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -3498,20 +3405,10 @@
         "statuses": "~1.5.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            }
-          }
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
@@ -3632,9 +3529,9 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-support": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
-      "integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -3667,9 +3564,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
-      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
       "dev": true
     },
     "sprintf-js": {
@@ -3730,9 +3627,9 @@
       }
     },
     "string_decoder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
-      "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -3829,9 +3726,9 @@
       }
     },
     "table": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.3.3.tgz",
-      "integrity": "sha512-3wUNCgdWX6PNpOe3amTTPWPuF6VGvgzjKCaO1snFj0z7Y3mUPWf5+zDtxUVGispJkDECPmR29wbzh6bVMOHbcw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.0.tgz",
+      "integrity": "sha512-nHFDrxmbrkU7JAFKqKbDJXfzrX2UBsWmrieXFTGxiI5e4ncg3VqsZeI4EzNmX0ncp4XNGVeoxIWJXfCIXwrsvw==",
       "dev": true,
       "requires": {
         "ajv": "^6.9.1",
@@ -3890,30 +3787,6 @@
         "readable-stream": "^2.3.0",
         "to-buffer": "^1.1.1",
         "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "tar.gz": {
@@ -4013,9 +3886,9 @@
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "ts-node": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.0.3.tgz",
-      "integrity": "sha512-2qayBA4vdtVRuDo11DEFSsD/SFsBXQBRZZhbRGSIkmYmVkWjULn/GGMdG10KVqkaGndljfaTD8dKjWgcejO8YA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.1.0.tgz",
+      "integrity": "sha512-34jpuOrxDuf+O6iW1JpgTRDFynUZ1iEqtYruBqh35gICNjN8x+LpVcPAcwzLPi9VU6mdA3ym+x233nZmZp445A==",
       "requires": {
         "arg": "^4.1.0",
         "diff": "^3.1.0",
@@ -4031,9 +3904,9 @@
       "dev": true
     },
     "tsutils": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.9.1.tgz",
-      "integrity": "sha512-hrxVtLtPqQr//p8/msPT1X1UYXUjizqSit5d9AQ5k38TcV38NyecL5xODNxa73cLe/5sdiJ+w1FqzDhRBA/anA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.10.0.tgz",
+      "integrity": "sha512-q20XSMq7jutbGB8luhKKsQldRKWvyBO2BGqni3p4yq8Ys9bEP/xQw3KepKmMRt9gJ4lvQSScrihJrcKdKoSU7Q==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
@@ -4085,9 +3958,9 @@
       }
     },
     "typescript": {
-      "version": "3.3.3333",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
-      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw=="
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw=="
     },
     "ultron": {
       "version": "1.1.1",
@@ -4208,9 +4081,9 @@
       "dev": true
     },
     "vscode-nls": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.0.tgz",
-      "integrity": "sha512-zKsFWVzL1wlCezgaI3XiN42IT8DIPM1Qr+G+RBhiU3U0bJCdC8pPELakRCtuVT4wF3gBZjBrUDQ8mowL7hmgwA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.1.tgz",
+      "integrity": "sha512-4R+2UoUUU/LdnMnFjePxfLqNhBS8lrAFyX7pjb2ud/lqDkrUavFUTcG7wR0HBZFakae0Q6KLBFjMS6W93F403A==",
       "dev": true
     },
     "vscode-uri": {
@@ -4508,21 +4381,6 @@
         "nan": "^2.3.3",
         "typedarray-to-buffer": "^3.1.2",
         "yaeti": "^0.0.6"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
       }
     },
     "which": {
@@ -4563,6 +4421,18 @@
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
         "winston-transport": "^4.3.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "winston-transport": {
@@ -4572,30 +4442,6 @@
       "requires": {
         "readable-stream": "^2.3.6",
         "triple-beam": "^1.2.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "wordwrap": {
@@ -4945,9 +4791,9 @@
       }
     },
     "yn": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.0.0.tgz",
-      "integrity": "sha512-+Wo/p5VRfxUgBUGy2j/6KX2mj9AYJWOHuhMjMcbBFc3y54o9/4buK1ksBvuiK01C3kby8DH9lSmJdSxw+4G/2Q=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.0.tgz",
+      "integrity": "sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "lint": "eslint src -c .eslintrc.json --ext ts",
     "package": "./package.sh",
     "prepack": "npm run package",
-    "test": "npm run test:unit && npm run test:smoke",
+    "test": "npm run test:unit && npm run test:smoke && npm run test:package",
     "test:unit": "mocha -r ts-node/register tests/**/*.test.ts tests/*.test.ts",
-    "test:smoke": "./tests/smoke.sh"
+    "test:smoke": "./tests/smoke.sh",
+    "test:package": "./tests/package.sh"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,17 @@
   "name": "@openst/mosaic-chains",
   "version": "0.1.0-alpha.1",
   "description": "Mosaic chains is an executable to run and manage mosaic chains.",
-  "main": "index.js",
+  "bin": {
+    "mosaic": "lib/src/bin/mosaic.js"
+  },
+  "main": "lib/index.js",
+  "files": [
+    "lib/**"
+  ],
   "scripts": {
     "lint": "eslint src -c .eslintrc.json --ext ts",
+    "package": "./package.sh",
+    "prepack": "npm run package",
     "test": "npm run test:unit && npm run test:smoke",
     "test:unit": "mocha -r ts-node/register tests/**/*.test.ts tests/*.test.ts",
     "test:smoke": "./tests/smoke.sh"
@@ -34,7 +42,7 @@
     "@types/fs-extra": "^5.0.5",
     "@types/mocha": "^5.2.6",
     "@types/node": "^11.11.3",
-    "@types/web3": "^1.0.18",
+    "@types/web3": "1.0.18",
     "@typescript-eslint/eslint-plugin": "^1.5.0",
     "@typescript-eslint/parser": "^1.4.2",
     "chai": "^4.2.0",

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+rm -rf ./lib
+npm ci
+
+./node_modules/.bin/tsc
+cp -r ./utility_chains ./lib/
+rm ./lib/package.json

--- a/package.sh
+++ b/package.sh
@@ -5,3 +5,4 @@ npm ci
 
 ./node_modules/.bin/tsc
 cp -r ./utility_chains ./lib/
+cp -r ./mosaic_config ./lib/

--- a/package.sh
+++ b/package.sh
@@ -5,4 +5,3 @@ npm ci
 
 ./node_modules/.bin/tsc
 cp -r ./utility_chains ./lib/
-rm ./lib/package.json

--- a/src/Directory.ts
+++ b/src/Directory.ts
@@ -46,8 +46,8 @@ export default class Directory {
    */
   public static getProjectMosaicConfigDir(): string {
     return path.join(
-        Directory.projectRoot,
-        `mosaic_config`,
+      Directory.projectRoot,
+      'mosaic_config',
     );
   }
 

--- a/src/bin/mosaic-attach.ts
+++ b/src/bin/mosaic-attach.ts
@@ -1,14 +1,12 @@
 #!/usr/bin/env node
 
 import * as mosaic from 'commander';
-import { version } from '../../package.json';
 import Shell from '../Shell';
 import Node from '../Node/Node';
 import NodeFactory from '../Node/NodeFactory';
 import NodeDescription from '../Node/NodeDescription';
 
 mosaic
-  .version(version)
   .arguments('<chain>')
   .action((chain: string) => {
     const node: Node = NodeFactory.create(new NodeDescription(chain));

--- a/src/bin/mosaic-create.ts
+++ b/src/bin/mosaic-create.ts
@@ -2,7 +2,6 @@
 
 import * as commander from 'commander';
 
-import { version } from '../../package.json';
 import Logger from '../Logger';
 import Initialization from '../NewChain/Initialization';
 import NodeOptions from './NodeOptions';
@@ -10,7 +9,6 @@ import NodeDescription from '../Node/NodeDescription';
 import Directory from '../Directory';
 
 let mosaic = commander
-  .version(version)
   .arguments('<new-chain-id> <origin-websocket> <password-file>');
 mosaic = NodeOptions.addCliOptions(mosaic);
 mosaic.action(

--- a/src/bin/mosaic-list.ts
+++ b/src/bin/mosaic-list.ts
@@ -1,12 +1,10 @@
 #!/usr/bin/env node
 
 import * as mosaic from 'commander';
-import { version } from '../../package.json';
 import Node from '../Node/Node';
 import Shell from '../Shell';
 
 mosaic
-  .version(version)
   .action(() => {
     const args = [
       'ps',

--- a/src/bin/mosaic-logs.ts
+++ b/src/bin/mosaic-logs.ts
@@ -1,14 +1,12 @@
 #!/usr/bin/env node
 
 import * as mosaic from 'commander';
-import { version } from '../../package.json';
 import Shell from '../Shell';
 import Node from '../Node/Node';
 import NodeDescription from '../Node/NodeDescription';
 import NodeFactory from '../Node/NodeFactory';
 
 mosaic
-  .version(version)
   .arguments('<chain>')
   .action((chain: string) => {
     const node: Node = NodeFactory.create(new NodeDescription(chain));

--- a/src/bin/mosaic-start.ts
+++ b/src/bin/mosaic-start.ts
@@ -1,13 +1,11 @@
 #!/usr/bin/env node
 
 import * as commander from 'commander';
-import { version } from '../../package.json';
 import NodeFactory from '../Node/NodeFactory';
 import Node from '../Node/Node';
 import NodeOptions from './NodeOptions';
 
 let mosaic = commander
-  .version(version)
   .arguments('<chain>');
 
 mosaic = NodeOptions.addCliOptions(mosaic);

--- a/src/bin/mosaic-stop.ts
+++ b/src/bin/mosaic-stop.ts
@@ -1,13 +1,11 @@
 #!/usr/bin/env node
 
 import * as mosaic from 'commander';
-import { version } from '../../package.json';
 import NodeFactory from '../Node/NodeFactory';
 import NodeDescription from '../Node/NodeDescription';
 import Node from '../Node/Node';
 
 mosaic
-  .version(version)
   .arguments('<chains...>')
   .action((chains: string[]) => {
     for (const chain of chains) {

--- a/src/bin/mosaic.ts
+++ b/src/bin/mosaic.ts
@@ -1,11 +1,8 @@
 #!/usr/bin/env node
 
 import * as mosaic from 'commander';
-import { version, description } from '../../package.json';
 
 mosaic
-  .version(version)
-  .description(description)
   .command('start <chain>', 'start container that runs a given chain')
   .command('stop <chains...>', 'stop the containers that run the given chains')
   .command('attach <chain>', 'attach to the ethereum node of the given chain')

--- a/tests/package.sh
+++ b/tests/package.sh
@@ -47,4 +47,4 @@ echo "Accessing as library."
 echo "Cleaning up generated files."
 clean
 
-echo "Successully Passed."
+echo "Successfully Passed."

--- a/tests/package.sh
+++ b/tests/package.sh
@@ -33,7 +33,7 @@ echo "Initiating npm project for test."
 npm init -y || exit 1
 npm install assert || exit 1
 
-echo "Installing openst-contract npm package into newly created project."
+echo "Installing openst-mosaic-chains npm package into newly created project."
 npm install openst-mosaic-chains-*.tgz || exit 1
 
 echo "Accessing as binary."

--- a/tests/package.sh
+++ b/tests/package.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+script_dir_path="$(cd "$(dirname "$0")" && pwd)"
+root_dir="${script_dir_path}/.."
+test_package_path="${script_dir_path}/package"
+
+function clean {
+    cd "${test_package_path}"
+
+    rm -rf "./node_modules" || exit 1
+    rm -f openst-mosaic-chains-*.tgz || exit 1
+    rm -f package.json || exit 1
+    rm -f package-lock.json || exit 1
+
+    cd -
+}
+
+clean
+
+echo "Switching to root directory."
+cd "${root_dir}" || exit 1
+
+echo "Executing \"npm pack\"."
+npm pack || exit 1
+
+echo "Switching to the package test directory."
+cd "${test_package_path}" || exit 1
+
+echo "Moving npm tarball into the test directory."
+mv $root_dir/openst-mosaic-chains-*.tgz . || exit 1
+
+echo "Initiating npm project for test."
+npm init -y || exit 1
+npm install assert || exit 1
+
+echo "Installing openst-contract npm package into newly created project."
+npm install openst-mosaic-chains-*.tgz || exit 1
+
+echo "Accessing as binary."
+./node_modules/.bin/mosaic start 1407 || exit 1
+./node_modules/.bin/mosaic list || exit 1
+./node_modules/.bin/mosaic stop 1407 || exit 1
+
+echo "Accessing as library."
+../../node_modules/.bin/ts-node "./index.ts" || exit 1
+
+echo "Cleaning up generated files."
+clean
+
+echo "Successully Passed."

--- a/tests/package/.gitignore
+++ b/tests/package/.gitignore
@@ -1,0 +1,4 @@
+package.json
+package-lock.json
+node_modules
+openst-mosaic-chains-*.tgz

--- a/tests/package/index.ts
+++ b/tests/package/index.ts
@@ -1,0 +1,7 @@
+import * as assert from 'assert';
+import { Node } from '@openst/mosaic-chains';
+
+assert.strictEqual(
+  Node.network,
+  'mosaic',
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,22 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "declaration": true,
         "module": "commonjs",
+        "outDir": "./lib",
+        "resolveJsonModule": true,
         "sourceMap": true,
+        "target": "es5",
         "types": [
             "chai",
             "fs-extra",
             "node",
             "mocha",
             "web3"
-        ],
-        "resolveJsonModule": true
+        ]
     },
     "include": [
-        "src/**/*.ts",
-        "src/bin/mosaic.ts",
-        "src/bin/mosaic-attach.ts"
+        "index.ts",
+        "src/**/*.ts"
     ],
     "exclude": [
         "node_modules"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
         "declaration": true,
         "module": "commonjs",
         "outDir": "./lib",
-        "resolveJsonModule": true,
         "sourceMap": true,
         "target": "es5",
         "types": [
@@ -17,8 +16,5 @@
     "include": [
         "index.ts",
         "src/**/*.ts"
-    ],
-    "exclude": [
-        "node_modules"
     ]
 }


### PR DESCRIPTION
Fixes #54

## Packaging
A new script `package.sh` takes care of the packaging process.
It compiles the TypeScript into the `./lib` directory as JavaScript.
It also copies the `utility_chains` directory. It has to copy the directory so that the relative imports from within the JavaScript files don't break.

## Testing Packaging
The `./tests` directory has a new script `package.sh` and a new directory `package`.
The `./tests/package.sh` script packages the mosaic chains project and installs the created package into a test project in `./tests/package/`.
It then accesses mosaic from `node_modules/.bin/mosaic` as well as from within a TypeScript file that imports the mosaic chains package.

This asserts that the code is accessible in executable form as well as as library.

## `package.json`
I kept the `version` at `0.1.0-alpha.1`. Happy to set anything else.

The `bin`, `main`, and `files` entries reference the compiled output inside `./lib`.

### Scripts

* `package` is a new run script that packages mosaic chains
* `prepack` ensures that packaging is executed before any run of `npm pack` or `npm publish`
* `test` has the additional `test:package` command
* `test:package` tests the packaging as described above

### Web3 Version

Because we depend on `@openst/mosaic.js`, we share web3 as a peer dependency with that package. Therefore, we cannot upgrade to a newer version of web3 as that breaks `@openst/mosaic.js`.

## `version` and `description` References
References from within the mosaic chains TypeScript files to the `package.json` file had to be removed. They resulted in a `package.json` file inside `./lib` as part of the TypeScript compilation output. This `./lib/package.json` was misleading the `npm pack` script and resulted in the wrong files being packaged.

Therefore, version and description can no longer be read from `package.json`. I removed it completely so that we won't have values that are out-of-sync in the future.