### PR TITLE
Added implementation of mosaic-config

### DIFF
--- a/src/Config/MosaicConfigV2.ts
+++ b/src/Config/MosaicConfigV2.ts
@@ -51,7 +51,7 @@ class AuxiliaryChain {
 }
 
 /**
- * Hold contract addresses on origin and auxiliary chain specific to a auxiliary chain.
+ * Hold contract addresses on origin and auxiliary chain specific to an auxiliary chain.
  */
 class ContractAddresses {
   public origin: OriginContracts;

--- a/src/Config/MosaicConfigV2.ts
+++ b/src/Config/MosaicConfigV2.ts
@@ -1,0 +1,89 @@
+import * as path from "path";
+import Directory from "../Directory";
+import Logger from "../Logger";
+import * as fs from "fs-extra";
+
+/**
+ * Holds the config of mosaic chains of a specific origin chain.
+ */
+export default class MosaicConfig {
+    public originChain: OriginChain;
+    public auxiliaryChains: AuxiliaryChain[];
+
+    /**
+     * Saves this config to a file in its auxiliary chain directory.
+     */
+    public writeToMosaicConfigDirectory(): void {
+        const configPath = path.join(
+            Directory.getProjectMosaicConfigDir(),
+            `${this.originChain.chain}.json`,
+        );
+        Logger.info('storing mosaic config', {configPath});
+
+        fs.writeFileSync(
+            configPath,
+            JSON.stringify(this, null, '    '),
+        );
+    }
+}
+
+/**
+ * Holds origin chain specific config.
+ */
+class OriginChain {
+    public chain: string;
+    public contractAddress: OriginLibraries;
+}
+
+/**
+ * Holds config of a auxiliary chain.
+ */
+class AuxiliaryChain {
+    public chainId: string;
+    public bootNodes: string[];
+    public genesis: Object;
+    public contractAddress: ContractAddresses;
+}
+
+/**
+ * Hold contract addresses on origin and auxiliary chain specific to a auxiliary chain.
+ */
+class ContractAddresses {
+    public origin: OriginContract;
+    public auxiliary: AuxiliaryContract;
+}
+
+/**
+ * Hold contract addresses on origin chain independent of auxiliary chain.
+ */
+class OriginLibraries {
+    public simpleTokenAddress: string;
+    public merklePatricialLibAddress: string;
+    public gatewayLibAddress: string;
+    public messageBusAddress: string;
+}
+
+/**
+ * Contract addresses on the origin chain specific to a auxiliary chain.
+ */
+class OriginContract {
+    public anchorOrganizationAddress: string;
+    public anchorAddress: string;
+    public ostGatewayOrganizationAddress: string;
+    public ostEIP20GatewayAddress: string;
+    public ostComposerAddress: string
+}
+
+/**
+ * Contract addresses on the auxiliary chain.
+ */
+class AuxiliaryContract {
+    public ostPrimeAddress: string;
+    public anchorOrganizationAddress: string;
+    public anchorAddress: string;
+    public merklePatriciaLibAddress: string;
+    public gatewayLibAddress: string;
+    public messageBusAddress: string;
+    public ostCoGatewayOrganizationAddress: string;
+    public ostEIP20CogatewayAddress: string;
+}

--- a/src/Config/MosaicConfigV2.ts
+++ b/src/Config/MosaicConfigV2.ts
@@ -1,14 +1,14 @@
 import * as path from "path";
+import * as fs from "fs-extra";
 import Directory from "../Directory";
 import Logger from "../Logger";
-import * as fs from "fs-extra";
 
 /**
  * Holds the config of mosaic chains of a specific origin chain.
  */
 export default class MosaicConfig {
     public originChain: OriginChain;
-    public auxiliaryChains: AuxiliaryChain[];
+    public auxiliaryChains: { [key: string]: AuxiliaryChain };
 
     /**
      * Saves this config to a file in its auxiliary chain directory.
@@ -32,7 +32,7 @@ export default class MosaicConfig {
  */
 class OriginChain {
     public chain: string;
-    public contractAddress: OriginLibraries;
+    public contractAddresses: OriginLibraries;
 }
 
 /**
@@ -42,48 +42,50 @@ class AuxiliaryChain {
     public chainId: string;
     public bootNodes: string[];
     public genesis: Object;
-    public contractAddress: ContractAddresses;
+    public contractAddresses: ContractAddresses;
 }
 
 /**
  * Hold contract addresses on origin and auxiliary chain specific to a auxiliary chain.
  */
 class ContractAddresses {
-    public origin: OriginContract;
-    public auxiliary: AuxiliaryContract;
+    public origin: OriginContracts;
+    public auxiliary: AuxiliaryContracts;
 }
 
 /**
  * Hold contract addresses on origin chain independent of auxiliary chain.
  */
 class OriginLibraries {
-    public simpleTokenAddress: string;
-    public merklePatricialLibAddress: string;
-    public gatewayLibAddress: string;
-    public messageBusAddress: string;
+    public simpleTokenAddress: Address;
+    public merklePatricialLibAddress: Address;
+    public gatewayLibAddress: Address;
+    public messageBusAddress: Address;
 }
 
 /**
  * Contract addresses on the origin chain specific to a auxiliary chain.
  */
-class OriginContract {
-    public anchorOrganizationAddress: string;
-    public anchorAddress: string;
-    public ostGatewayOrganizationAddress: string;
-    public ostEIP20GatewayAddress: string;
-    public ostComposerAddress: string
+class OriginContracts {
+    public anchorOrganizationAddress: Address;
+    public anchorAddress: Address;
+    public ostGatewayOrganizationAddress: Address;
+    public ostEIP20GatewayAddress: Address;
+    public ostComposerAddress: Address
 }
 
 /**
  * Contract addresses on the auxiliary chain.
  */
-class AuxiliaryContract {
-    public ostPrimeAddress: string;
-    public anchorOrganizationAddress: string;
-    public anchorAddress: string;
-    public merklePatriciaLibAddress: string;
-    public gatewayLibAddress: string;
-    public messageBusAddress: string;
-    public ostCoGatewayOrganizationAddress: string;
-    public ostEIP20CogatewayAddress: string;
+class AuxiliaryContracts {
+    public ostPrimeAddress: Address;
+    public anchorOrganizationAddress: Address;
+    public anchorAddress: Address;
+    public merklePatriciaLibAddress: Address;
+    public gatewayLibAddress: Address;
+    public messageBusAddress: Address;
+    public ostCoGatewayOrganizationAddress: Address;
+    public ostEIP20CogatewayAddress: Address;
 }
+
+type Address = string;

--- a/src/Config/MosaicConfigV2.ts
+++ b/src/Config/MosaicConfigV2.ts
@@ -1,91 +1,111 @@
-import * as path from "path";
-import * as fs from "fs-extra";
-import Directory from "../Directory";
-import Logger from "../Logger";
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import Directory from '../Directory';
+import Logger from '../Logger';
 
 /**
  * Holds the config of mosaic chains of a specific origin chain.
  */
 export default class MosaicConfig {
-    public originChain: OriginChain;
-    public auxiliaryChains: { [key: string]: AuxiliaryChain };
+  public originChain: OriginChain;
 
-    /**
+  public auxiliaryChains: { [key: string]: AuxiliaryChain };
+
+  /**
      * Saves this config to a file in its auxiliary chain directory.
      */
-    public writeToMosaicConfigDirectory(): void {
-        const configPath = path.join(
-            Directory.getProjectMosaicConfigDir(),
-            `${this.originChain.chain}.json`,
-        );
-        Logger.info('storing mosaic config', {configPath});
+  public writeToMosaicConfigDirectory(): void {
+    const configPath = path.join(
+      Directory.getProjectMosaicConfigDir(),
+      `${this.originChain.chain}.json`,
+    );
+    Logger.info('storing mosaic config', { configPath });
 
-        fs.writeFileSync(
-            configPath,
-            JSON.stringify(this, null, '    '),
-        );
-    }
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(this, null, '    '),
+    );
+  }
 }
 
 /**
  * Holds origin chain specific config.
  */
 class OriginChain {
-    public chain: string;
-    public contractAddresses: OriginLibraries;
+  public chain: string;
+
+  public contractAddresses: OriginLibraries;
 }
 
 /**
- * Holds config of a auxiliary chain.
+ * Holds config of an auxiliary chain.
  */
 class AuxiliaryChain {
-    public chainId: string;
-    public bootNodes: string[];
-    public genesis: Object;
-    public contractAddresses: ContractAddresses;
+  public chainId: string;
+
+  public bootNodes: string[];
+
+  public genesis: Object;
+
+  public contractAddresses: ContractAddresses;
 }
 
 /**
  * Hold contract addresses on origin and auxiliary chain specific to a auxiliary chain.
  */
 class ContractAddresses {
-    public origin: OriginContracts;
-    public auxiliary: AuxiliaryContracts;
+  public origin: OriginContracts;
+
+  public auxiliary: AuxiliaryContracts;
 }
 
 /**
  * Hold contract addresses on origin chain independent of auxiliary chain.
  */
 class OriginLibraries {
-    public simpleTokenAddress: Address;
-    public merklePatricialLibAddress: Address;
-    public gatewayLibAddress: Address;
-    public messageBusAddress: Address;
+  public simpleTokenAddress: Address;
+
+  public merklePatricialLibAddress: Address;
+
+  public gatewayLibAddress: Address;
+
+  public messageBusAddress: Address;
 }
 
 /**
- * Contract addresses on the origin chain specific to a auxiliary chain.
+ * Contract addresses on the origin chain specific to an auxiliary chain.
  */
 class OriginContracts {
-    public anchorOrganizationAddress: Address;
-    public anchorAddress: Address;
-    public ostGatewayOrganizationAddress: Address;
-    public ostEIP20GatewayAddress: Address;
-    public ostComposerAddress: Address
+  public anchorOrganizationAddress: Address;
+
+  public anchorAddress: Address;
+
+  public ostGatewayOrganizationAddress: Address;
+
+  public ostEIP20GatewayAddress: Address;
+
+  public ostComposerAddress: Address
 }
 
 /**
  * Contract addresses on the auxiliary chain.
  */
 class AuxiliaryContracts {
-    public ostPrimeAddress: Address;
-    public anchorOrganizationAddress: Address;
-    public anchorAddress: Address;
-    public merklePatriciaLibAddress: Address;
-    public gatewayLibAddress: Address;
-    public messageBusAddress: Address;
-    public ostCoGatewayOrganizationAddress: Address;
-    public ostEIP20CogatewayAddress: Address;
+  public ostPrimeAddress: Address;
+
+  public anchorOrganizationAddress: Address;
+
+  public anchorAddress: Address;
+
+  public merklePatriciaLibAddress: Address;
+
+  public gatewayLibAddress: Address;
+
+  public messageBusAddress: Address;
+
+  public ostCoGatewayOrganizationAddress: Address;
+
+  public ostEIP20CogatewayAddress: Address;
 }
 
 type Address = string;


### PR DESCRIPTION
This partially fixes 56(Please don't close 56). It is created to unblock remaining tickets of mosaic chains. 

This PR implements mosaic config class. Currently, there exists a `MosaicConfig` in the project which is used everywhere. So the new mosaic config is named as `MosaicConfigV2`. This should be renamed back to `MosaicConfig` when the usage of the old mosaic config is updated to the new mosaic config. 
