### PR TITLE
Default api for rpc and ws is eth

### DIFF
--- a/src/Node/GethNode.ts
+++ b/src/Node/GethNode.ts
@@ -98,14 +98,24 @@ export default class GethNode extends Node {
       '--rpc',
       '--rpcaddr', '0.0.0.0',
       '--rpcvhosts', '*',
-      '--rpcapi', 'eth,net,web3,network,debug,txpool,admin,personal',
       '--rpcport', '8545',
       '--ws',
       '--wsaddr', '0.0.0.0',
       '--wsport', '8546',
-      '--wsapi', 'eth,net,web3,network,debug,txpool,admin,personal',
       '--wsorigins', '*',
     ]);
+
+    if(this.debug) {
+      args = args.concat([
+        '--rpcapi', 'eth,net,web3,network,debug,txpool,admin,personal',
+        '--wsapi', 'eth,net,web3,network,debug,txpool,admin,personal',
+      ]);
+    } else {
+      args = args.concat([
+        '--rpcapi', 'eth',
+        '--wsapi', 'eth',
+      ]);
+    }
 
     if (this.bootnodes !== '') {
       args = args.concat([

--- a/src/Node/Node.ts
+++ b/src/Node/Node.ts
@@ -46,6 +46,12 @@ export default abstract class Node {
   public originChain: string;
 
   /**
+   * If true then eth, net, web3, network, debug, txpool, admin, personal api's are enabled.
+   * Otherwise only eth api is enabled.
+   */
+  public debug: boolean;
+
+  /**
    * Docker container names will have this prefix.
    * @returns The prefix.
    */
@@ -71,6 +77,7 @@ export default abstract class Node {
     this.unlock = nodeDescription.unlock;
     this.password = nodeDescription.password;
     this.originChain = nodeDescription.originChain;
+    this.debug = nodeDescription.debug;
 
     if (this.originChain === '') {
       this.chainDir = path.join(this.mosaicDir, this.chain, 'origin');

--- a/src/Node/NodeDescription.ts
+++ b/src/Node/NodeDescription.ts
@@ -20,5 +20,7 @@ export default class NodeDescription {
 
   public originChain: string = '';
 
+  public debug: boolean = false;
+
   constructor(readonly chain: string) { }
 }

--- a/src/bin/NodeOptions.ts
+++ b/src/bin/NodeOptions.ts
@@ -45,6 +45,12 @@ export default class NodeOptions {
   public originChain: string;
 
   /**
+   * If true then eth, net, web3, network, debug, txpool, admin, personal api's are enabled.
+   * Otherwise only eth api is enabled.
+   */
+  public debug: boolean;
+
+  /**
    * @param options The options from the command line.
    */
   constructor(options: {
@@ -56,6 +62,7 @@ export default class NodeOptions {
     unlock: string;
     password: string;
     originChain: string;
+    debug: string;
   }) {
     Object.assign(this, options);
   }
@@ -94,6 +101,7 @@ export default class NodeOptions {
       unlock: options.unlock || '',
       password: options.password || '',
       originChain: options.origin || '',
+      debug: options.debug || '',
     });
 
     parsedOptions.mosaicDir = Directory.sanitize(parsedOptions.mosaicDir);

--- a/src/bin/mosaic-start.ts
+++ b/src/bin/mosaic-start.ts
@@ -19,6 +19,7 @@ mosaic
   .option('-u,--unlock <accounts>', 'a comma separated list of accounts that get unlocked in the node; you must use this together with --password')
   .option('-s,--password <file>', 'the path to the password file on your machine; you must use this together with --unlock')
   .option('-g,--withoutGraphNode', 'boolean flag which decides if graph node should be started')
+  .option('-d,--debug','boolean flag determining whether chain to be started in debug mode; if not provided then chain starts with only eth api enabled for ws and rpc')
   .action((chain: string, options) => {
     const {
       mosaicDir,
@@ -29,6 +30,7 @@ mosaic
       unlock,
       password,
       originChain,
+      debug,
     } = NodeOptions.parseOptions(options, chain);
     const node: Node = NodeFactory.create({
       chain,
@@ -40,6 +42,7 @@ mosaic
       unlock,
       password,
       originChain,
+      debug,
     });
     node.start();
 


### PR DESCRIPTION
PR contains changes to enable only `eth`api.
However, for development/testing, `--debug` option is available when starting(`./mosaic start`) the chain. It will provide eth, net, web3, network, debug, txpool, admin, personal api's for ws and rpc endpoints.